### PR TITLE
스터디 보고서 관리 테스트 업데이트

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,7 +11,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "develop" ]
 
 permissions:
   contents: read

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.mockito:mockito-core:5.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/edu/handong/csee/histudy/repository/AcademicTermRepository.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/AcademicTermRepository.java
@@ -3,9 +3,7 @@ package edu.handong.csee.histudy.repository;
 import edu.handong.csee.histudy.domain.AcademicTerm;
 import edu.handong.csee.histudy.domain.TermType;
 import java.util.Optional;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface AcademicTermRepository {
   Optional<AcademicTerm> findCurrentSemester();
 

--- a/src/main/java/edu/handong/csee/histudy/repository/CourseRepository.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/CourseRepository.java
@@ -3,9 +3,7 @@ package edu.handong.csee.histudy.repository;
 import edu.handong.csee.histudy.domain.Course;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface CourseRepository {
   List<Course> findAllByNameContainingIgnoreCase(String keyword);
 

--- a/src/main/java/edu/handong/csee/histudy/repository/StudyApplicantRepository.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/StudyApplicantRepository.java
@@ -6,9 +6,7 @@ import edu.handong.csee.histudy.domain.StudyGroup;
 import edu.handong.csee.histudy.domain.User;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface StudyApplicantRepository {
   Optional<StudyApplicant> findByUserAndTerm(User applicant, AcademicTerm currentTerm);
 

--- a/src/main/java/edu/handong/csee/histudy/repository/StudyGroupRepository.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/StudyGroupRepository.java
@@ -5,9 +5,7 @@ import edu.handong.csee.histudy.domain.StudyGroup;
 import edu.handong.csee.histudy.domain.User;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface StudyGroupRepository {
   Optional<StudyGroup> findByTagAndAcademicTerm(int tag, AcademicTerm academicTerm);
 

--- a/src/main/java/edu/handong/csee/histudy/repository/StudyReportRepository.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/StudyReportRepository.java
@@ -4,9 +4,7 @@ import edu.handong.csee.histudy.domain.StudyGroup;
 import edu.handong.csee.histudy.domain.StudyReport;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface StudyReportRepository {
   List<StudyReport> findAllByStudyGroupOrderByCreatedDateDesc(StudyGroup studyGroup);
 

--- a/src/main/java/edu/handong/csee/histudy/repository/UserRepository.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/UserRepository.java
@@ -4,9 +4,7 @@ import edu.handong.csee.histudy.domain.User;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Sort;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface UserRepository {
   Optional<User> findUserBySid(String sid);
 

--- a/src/main/java/edu/handong/csee/histudy/repository/impl/AcademicTermRepositoryImpl.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/impl/AcademicTermRepositoryImpl.java
@@ -6,7 +6,9 @@ import edu.handong.csee.histudy.repository.AcademicTermRepository;
 import edu.handong.csee.histudy.repository.jpa.JpaAcademicTermRepository;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
+@Repository
 @RequiredArgsConstructor
 public class AcademicTermRepositoryImpl implements AcademicTermRepository {
   private final JpaAcademicTermRepository repository;

--- a/src/main/java/edu/handong/csee/histudy/repository/impl/CourseRepositoryImpl.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/impl/CourseRepositoryImpl.java
@@ -6,7 +6,9 @@ import edu.handong.csee.histudy.repository.jpa.JpaCourseRepository;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
+@Repository
 @RequiredArgsConstructor
 public class CourseRepositoryImpl implements CourseRepository {
   private final JpaCourseRepository repository;

--- a/src/main/java/edu/handong/csee/histudy/repository/impl/StudyApplicationRepositoryImpl.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/impl/StudyApplicationRepositoryImpl.java
@@ -9,7 +9,9 @@ import edu.handong.csee.histudy.repository.jpa.JpaStudyApplicantRepository;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
+@Repository
 @RequiredArgsConstructor
 public class StudyApplicationRepositoryImpl implements StudyApplicantRepository {
   private final JpaStudyApplicantRepository repository;

--- a/src/main/java/edu/handong/csee/histudy/repository/impl/StudyGroupRepositoryImpl.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/impl/StudyGroupRepositoryImpl.java
@@ -8,7 +8,9 @@ import edu.handong.csee.histudy.repository.jpa.JpaStudyGroupRepository;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
+@Repository
 @RequiredArgsConstructor
 public class StudyGroupRepositoryImpl implements StudyGroupRepository {
   private final JpaStudyGroupRepository repository;

--- a/src/main/java/edu/handong/csee/histudy/repository/impl/StudyReportRepositoryImpl.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/impl/StudyReportRepositoryImpl.java
@@ -7,7 +7,9 @@ import edu.handong.csee.histudy.repository.jpa.JpaStudyReportRepository;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
+@Repository
 @RequiredArgsConstructor
 public class StudyReportRepositoryImpl implements StudyReportRepository {
   private final JpaStudyReportRepository repository;

--- a/src/main/java/edu/handong/csee/histudy/repository/impl/UserRepositoryImpl.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/impl/UserRepositoryImpl.java
@@ -7,7 +7,9 @@ import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
 
+@Repository
 @RequiredArgsConstructor
 public class UserRepositoryImpl implements UserRepository {
   private final JpaUserRepository repository;

--- a/src/test/java/edu/handong/csee/histudy/service/CourseServiceTest.java
+++ b/src/test/java/edu/handong/csee/histudy/service/CourseServiceTest.java
@@ -9,10 +9,7 @@ import edu.handong.csee.histudy.service.repository.fake.*;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
 public class CourseServiceTest {
 
   private CourseService courseService;
@@ -21,7 +18,7 @@ public class CourseServiceTest {
   private UserRepository userRepository;
   private AcademicTermRepository academicTermRepository;
   private StudyGroupRepository studyGroupRepository;
-  private StudyApplicantRepository studyApplicationRepository;
+  private StudyApplicantRepository studyApplicantRepository;
 
   @BeforeEach
   void init() {
@@ -29,7 +26,7 @@ public class CourseServiceTest {
     userRepository = new FakeUserRepository();
     academicTermRepository = new FakeAcademicTermRepository();
     studyGroupRepository = new FakeStudyGroupRepository();
-    studyApplicationRepository = new FakeStudyApplicationRepository();
+    studyApplicantRepository = new FakeStudyApplicationRepository();
 
     courseService =
         new CourseService(
@@ -37,21 +34,41 @@ public class CourseServiceTest {
             userRepository,
             academicTermRepository,
             studyGroupRepository,
-            studyApplicationRepository);
-  }
+            studyApplicantRepository);
 
-  @Test
-  void 강의목록_검색_전체() {
-    // Given
     AcademicTerm term =
         AcademicTerm.builder().academicYear(2025).semester(TermType.SPRING).isCurrent(true).build();
     academicTermRepository.save(term);
+
+    User student1 =
+        User.builder().sub("1").sid("22500101").email("user1@test.com").name("Foo").build();
+
+    User student2 =
+        User.builder().sub("2").sid("22500102").email("user2@test.com").name("Bar").build();
+
+    userRepository.save(student1);
+    userRepository.save(student2);
 
     Course course1 = new Course("Introduction to Algorithms", "ECE00101", "John Doe", term);
     Course course2 = new Course("Introduction to Data Structures", "ECE00102", "John Doe", term);
 
     courseRepository.saveAll(List.of(course1, course2));
 
+    StudyApplicant studyApplicant1 =
+        StudyApplicant.of(term, student1, List.of(student2), List.of(course1));
+
+    StudyApplicant studyApplicant2 =
+        StudyApplicant.of(term, student2, List.of(student1), List.of(course2));
+
+    studyApplicantRepository.save(studyApplicant1);
+    studyApplicantRepository.save(studyApplicant2);
+
+    StudyGroup studyGroup = StudyGroup.of(1, term, List.of(studyApplicant1, studyApplicant2));
+    studyGroupRepository.save(studyGroup);
+  }
+
+  @Test
+  void 강의목록_검색_전체() {
     // When
     List<CourseDto.CourseInfo> courses = courseService.getCurrentCourses();
 
@@ -61,16 +78,6 @@ public class CourseServiceTest {
 
   @Test
   void 강의목록_검색_키워드() {
-    // Given
-    AcademicTerm term =
-        AcademicTerm.builder().academicYear(2025).semester(TermType.SPRING).isCurrent(true).build();
-    academicTermRepository.save(term);
-
-    Course course1 = new Course("Introduction to Algorithms", "ECE00101", "John Doe", term);
-    Course course2 = new Course("Introduction to Data Structures", "ECE00102", "John Doe", term);
-
-    courseRepository.saveAll(List.of(course1, course2));
-
     // When
     String keyword1 = "algo";
     String keyword2 = "intro";
@@ -81,5 +88,14 @@ public class CourseServiceTest {
     // Then
     assertThat(res1.size()).isEqualTo(1);
     assertThat(res2.size()).isEqualTo(2);
+  }
+
+  @Test
+  void 스터디그룹_선택과목_목록_조회() {
+    // When
+    List<CourseDto.CourseInfo> res = courseService.getTeamCourses("user1@test.com");
+
+    // Then
+    assertThat(res.size()).isEqualTo(2);
   }
 }

--- a/src/test/java/edu/handong/csee/histudy/service/ImageServiceTest.java
+++ b/src/test/java/edu/handong/csee/histudy/service/ImageServiceTest.java
@@ -1,0 +1,137 @@
+package edu.handong.csee.histudy.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import edu.handong.csee.histudy.domain.*;
+import edu.handong.csee.histudy.repository.*;
+import edu.handong.csee.histudy.service.repository.fake.*;
+import edu.handong.csee.histudy.util.ImagePathMapper;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+public class ImageServiceTest {
+
+  private ImageService imageService;
+
+  private final String origin = "http://localhost:8080";
+  private final String imageBasePath = "/reports/images/";
+
+  @TempDir private File tempDir;
+
+  @BeforeEach
+  void init() {
+    StudyGroupRepository studyGroupRepository = new FakeStudyGroupRepository();
+    UserRepository userRepository = new FakeUserRepository();
+    AcademicTermRepository academicTermRepository = new FakeAcademicTermRepository();
+    StudyApplicantRepository studyApplicantRepository = new FakeStudyApplicationRepository();
+    StudyReportRepository studyReportRepository = new FakeStudyReportRepository();
+    CourseRepository courseRepository = new FakeCourseRepository();
+    ImagePathMapper imagePathMapper = new ImagePathMapper();
+
+    ReflectionTestUtils.setField(imagePathMapper, "origin", origin);
+    ReflectionTestUtils.setField(imagePathMapper, "imageBasePath", imageBasePath);
+
+    imageService =
+        new ImageService(
+            academicTermRepository,
+            userRepository,
+            studyReportRepository,
+            studyApplicantRepository,
+            imagePathMapper,
+            studyGroupRepository);
+
+    ReflectionTestUtils.setField(imageService, "imageBaseLocation", tempDir + File.separator);
+
+    // Setup
+    AcademicTerm term =
+        AcademicTerm.builder().academicYear(2025).semester(TermType.SPRING).isCurrent(true).build();
+    academicTermRepository.save(term);
+
+    User student1 =
+        User.builder().sub("1").sid("22500101").email("user1@test.com").name("Foo").build();
+
+    User student2 =
+        User.builder().sub("2").sid("22500102").email("user2@test.com").name("Bar").build();
+
+    userRepository.save(student1);
+    userRepository.save(student2);
+
+    Course course = new Course("Introduction to Test", "ECE00103", "John", term);
+    courseRepository.saveAll(List.of(course));
+
+    StudyApplicant studyApplicant1 =
+        StudyApplicant.of(term, student1, List.of(student2), List.of(course));
+
+    StudyApplicant studyApplicant2 =
+        StudyApplicant.of(term, student2, List.of(student1), List.of(course));
+
+    studyApplicantRepository.save(studyApplicant1);
+    studyApplicantRepository.save(studyApplicant2);
+
+    StudyGroup studyGroup = StudyGroup.of(1, term, List.of(studyApplicant1, studyApplicant2));
+    studyGroupRepository.save(studyGroup);
+
+    StudyReport report =
+        StudyReport.builder()
+            .title("title")
+            .content("content")
+            .totalMinutes(60L)
+            .courses(List.of(course))
+            .participants(List.of(student1))
+            .images(List.of("/path/to/image1.png"))
+            .studyGroup(studyGroup)
+            .build();
+    studyReportRepository.save(report);
+
+    IntStream.range(0, report.getImages().size())
+        .forEach(
+            i ->
+                ReflectionTestUtils.setField(
+                    report.getImages().get(i), "reportImageId", (long) i + 1));
+  }
+
+  @Test
+  void 스터디보고서_이미지_업로드_최초() throws IOException {
+    // Given
+    MultipartFile data = mock(MultipartFile.class);
+    doNothing().when(data).transferTo(any(File.class));
+
+    // When
+    String imagePath = imageService.getImagePaths("user1@test.com", data, Optional.empty());
+
+    // Then
+    assertThat(imagePath).contains(origin, imageBasePath);
+  }
+
+  @Test
+  void 스터디보고서_이미지_업로드_수정() throws IOException {
+    try (MockedStatic<Files> fileMockedStatic = Mockito.mockStatic(Files.class)) {
+      MultipartFile data = mock(MultipartFile.class);
+      doNothing().when(data).transferTo(any(File.class));
+
+      byte[] sameContent = "content".getBytes();
+      fileMockedStatic.when(() -> Files.readAllBytes(any(Path.class))).thenReturn(sameContent);
+
+      String imagePath = imageService.getImagePaths("user1@test.com", data, Optional.of(1L));
+
+      assertThat(imagePath).contains(origin, imageBasePath);
+    }
+  }
+}

--- a/src/test/java/edu/handong/csee/histudy/service/ReportServiceTest.java
+++ b/src/test/java/edu/handong/csee/histudy/service/ReportServiceTest.java
@@ -1,0 +1,163 @@
+package edu.handong.csee.histudy.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import edu.handong.csee.histudy.controller.form.ReportForm;
+import edu.handong.csee.histudy.domain.*;
+import edu.handong.csee.histudy.dto.ReportDto;
+import edu.handong.csee.histudy.repository.*;
+import edu.handong.csee.histudy.service.repository.fake.*;
+import edu.handong.csee.histudy.util.ImagePathMapper;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+public class ReportServiceTest {
+
+  private ReportService reportService;
+
+  @BeforeEach
+  void init() {
+    StudyGroupRepository studyGroupRepository = new FakeStudyGroupRepository();
+    UserRepository userRepository = new FakeUserRepository();
+    AcademicTermRepository academicTermRepository = new FakeAcademicTermRepository();
+    StudyApplicantRepository studyApplicantRepository = new FakeStudyApplicationRepository();
+    StudyReportRepository studyReportRepository = new FakeStudyReportRepository();
+    CourseRepository courseRepository = new FakeCourseRepository();
+    ImagePathMapper imagePathMapper = new ImagePathMapper();
+
+    reportService =
+        new ReportService(
+            studyReportRepository,
+            userRepository,
+            courseRepository,
+            studyGroupRepository,
+            academicTermRepository,
+            imagePathMapper);
+
+    // Setup
+    AcademicTerm term =
+        AcademicTerm.builder().academicYear(2025).semester(TermType.SPRING).isCurrent(true).build();
+    academicTermRepository.save(term);
+
+    User student1 =
+        User.builder().sub("1").sid("22500101").email("user1@test.com").name("Foo").build();
+
+    User student2 =
+        User.builder().sub("2").sid("22500102").email("user2@test.com").name("Bar").build();
+
+    userRepository.save(student1);
+    userRepository.save(student2);
+
+    Course course = new Course("Introduction to Test", "ECE00103", "John", term);
+    courseRepository.saveAll(List.of(course));
+
+    StudyApplicant studyApplicant1 =
+        StudyApplicant.of(term, student1, List.of(student2), List.of(course));
+
+    StudyApplicant studyApplicant2 =
+        StudyApplicant.of(term, student2, List.of(student1), List.of(course));
+
+    studyApplicantRepository.save(studyApplicant1);
+    studyApplicantRepository.save(studyApplicant2);
+
+    StudyGroup studyGroup = StudyGroup.of(1, term, List.of(studyApplicant1, studyApplicant2));
+    studyGroupRepository.save(studyGroup);
+
+    StudyReport report =
+        StudyReport.builder()
+            .title("title")
+            .content("content")
+            .totalMinutes(60L)
+            .courses(List.of(course))
+            .participants(List.of(student1))
+            .images(List.of("/path/to/image1.png"))
+            .studyGroup(studyGroup)
+            .build();
+    studyReportRepository.save(report);
+
+    IntStream.range(0, report.getImages().size())
+        .forEach(
+            i ->
+                ReflectionTestUtils.setField(
+                    report.getImages().get(i), "reportImageId", (long) i + 1));
+  }
+
+  @Test
+  void 스터디보고서_작성() {
+    // Given
+    ReportForm form =
+        ReportForm.builder()
+            .title("title2")
+            .content("content2")
+            .totalMinutes(120L)
+            .participants(List.of())
+            .courses(List.of())
+            .build();
+
+    // When
+    ReportDto.ReportInfo report = reportService.createReport(form, "user1@test.com");
+
+    // Then
+    assertThat(report.getTitle()).isEqualTo("title2");
+  }
+
+  @Test
+  void 스터디보고서_목록_조회() {
+    // When
+    List<ReportDto.ReportInfo> reports = reportService.getReports("user1@test.com");
+
+    // Then
+    assertThat(reports.size()).isEqualTo(1);
+  }
+
+  @Test
+  void 스터디보고서_상세_조회() {
+    // When
+    Optional<ReportDto.ReportInfo> reportOr1 = reportService.getReport(1L);
+    Optional<ReportDto.ReportInfo> reportOr2 = reportService.getReport(2L);
+
+    // Then
+    assertThat(reportOr1.isPresent()).isTrue();
+    assertThat(reportOr2.isPresent()).isFalse();
+  }
+
+  @Test
+  void 스터디보고서_수정() {
+    // Given
+    ReportForm form =
+        ReportForm.builder()
+            .title("modifiedTitle")
+            .participants(List.of())
+            .courses(List.of())
+            .build();
+
+    // When
+    reportService.updateReport(1L, form);
+    Optional<ReportDto.ReportInfo> report = reportService.getReport(1L);
+
+    // Then
+    assertThat(report.isPresent()).isTrue();
+    assertThat(report.get().getTitle()).isEqualTo("modifiedTitle");
+  }
+
+  @Test
+  void 스터디보고서_삭제() {
+    // When
+    Optional<ReportDto.ReportInfo> reportOrBefore = reportService.getReport(1L);
+    reportService.deleteReport(1L);
+    Optional<ReportDto.ReportInfo> reportOrAfter = reportService.getReport(1L);
+
+    // Then
+    assertThat(reportOrBefore.isPresent()).isTrue();
+    assertThat(reportOrAfter.isPresent()).isFalse();
+  }
+}

--- a/src/test/java/edu/handong/csee/histudy/service/TeamServiceTest.java
+++ b/src/test/java/edu/handong/csee/histudy/service/TeamServiceTest.java
@@ -1,0 +1,108 @@
+package edu.handong.csee.histudy.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import edu.handong.csee.histudy.domain.*;
+import edu.handong.csee.histudy.dto.UserDto;
+import edu.handong.csee.histudy.repository.*;
+import edu.handong.csee.histudy.service.repository.fake.*;
+import edu.handong.csee.histudy.util.ImagePathMapper;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+public class TeamServiceTest {
+
+  private TeamService teamService;
+
+  private final String origin = "http://localhost:8080";
+  private final String imageBasePath = "/reports/images/";
+
+  @BeforeEach
+  void init() {
+    StudyGroupRepository studyGroupRepository = new FakeStudyGroupRepository();
+    UserRepository userRepository = new FakeUserRepository();
+    AcademicTermRepository academicTermRepository = new FakeAcademicTermRepository();
+    StudyApplicantRepository studyApplicantRepository = new FakeStudyApplicationRepository();
+    StudyReportRepository studyReportRepository = new FakeStudyReportRepository();
+    CourseRepository courseRepository = new FakeCourseRepository();
+    ImagePathMapper imagePathMapper = new ImagePathMapper();
+
+    ReflectionTestUtils.setField(imagePathMapper, "origin", origin);
+    ReflectionTestUtils.setField(imagePathMapper, "imageBasePath", imageBasePath);
+
+    teamService =
+        new TeamService(
+            studyGroupRepository,
+            userRepository,
+            academicTermRepository,
+            studyApplicantRepository,
+            studyReportRepository,
+            imagePathMapper);
+
+    // Setup
+    AcademicTerm term =
+        AcademicTerm.builder().academicYear(2025).semester(TermType.SPRING).isCurrent(true).build();
+    academicTermRepository.save(term);
+
+    User student1 =
+        User.builder().sub("1").sid("22500101").email("user1@test.com").name("Foo").build();
+
+    User student2 =
+        User.builder().sub("2").sid("22500102").email("user2@test.com").name("Bar").build();
+
+    userRepository.save(student1);
+    userRepository.save(student2);
+
+    Course course = new Course("Introduction to Test", "ECE00103", "John", term);
+    courseRepository.saveAll(List.of(course));
+
+    StudyApplicant studyApplicant1 =
+        StudyApplicant.of(term, student1, List.of(student2), List.of(course));
+
+    StudyApplicant studyApplicant2 =
+        StudyApplicant.of(term, student2, List.of(student1), List.of(course));
+
+    studyApplicantRepository.save(studyApplicant1);
+    studyApplicantRepository.save(studyApplicant2);
+
+    StudyGroup studyGroup = StudyGroup.of(1, term, List.of(studyApplicant1, studyApplicant2));
+    studyGroupRepository.save(studyGroup);
+
+    StudyReport report =
+        StudyReport.builder()
+            .title("title")
+            .content("content")
+            .totalMinutes(60L)
+            .courses(List.of(course))
+            .participants(List.of(student1))
+            .images(List.of("/path/to/image1.png"))
+            .studyGroup(studyGroup)
+            .build();
+    studyReportRepository.save(report);
+
+    IntStream.range(0, report.getImages().size())
+        .forEach(
+            i ->
+                ReflectionTestUtils.setField(
+                    report.getImages().get(i), "reportImageId", (long) i + 1));
+  }
+
+  @Test
+  void 그룹원정보확인_학번은_마스킹되어있어야함() {
+    // When
+    List<UserDto.UserMeWithMasking> teamUsers = teamService.getTeamUsers("user1@test.com");
+
+    // Then
+    assertThat(teamUsers.size()).isEqualTo(2);
+    assertThat(teamUsers.get(0).getTag()).isEqualTo(1);
+    assertThat(teamUsers.get(1).getSid()).contains("*");
+  }
+}

--- a/src/test/java/edu/handong/csee/histudy/service/UserServiceTest.java
+++ b/src/test/java/edu/handong/csee/histudy/service/UserServiceTest.java
@@ -9,10 +9,7 @@ import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
 public class UserServiceTest {
 
   private UserService userService;

--- a/src/test/java/edu/handong/csee/histudy/service/repository/fake/FakeAcademicTermRepository.java
+++ b/src/test/java/edu/handong/csee/histudy/service/repository/fake/FakeAcademicTermRepository.java
@@ -6,10 +6,12 @@ import edu.handong.csee.histudy.repository.AcademicTermRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.test.util.ReflectionTestUtils;
 
 public class FakeAcademicTermRepository implements AcademicTermRepository {
 
   private final List<AcademicTerm> store = new ArrayList<>();
+  private Long sequence = 1L;
 
   @Override
   public Optional<AcademicTerm> findCurrentSemester() {
@@ -25,6 +27,7 @@ public class FakeAcademicTermRepository implements AcademicTermRepository {
 
   @Override
   public AcademicTerm save(AcademicTerm entity) {
+    ReflectionTestUtils.setField(entity, "academicTermId", sequence++);
     store.add(entity);
     return entity;
   }

--- a/src/test/java/edu/handong/csee/histudy/service/repository/fake/FakeCourseRepository.java
+++ b/src/test/java/edu/handong/csee/histudy/service/repository/fake/FakeCourseRepository.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.springframework.test.util.ReflectionTestUtils;
 
 public class FakeCourseRepository implements CourseRepository {
 
@@ -26,16 +27,7 @@ public class FakeCourseRepository implements CourseRepository {
 
   @Override
   public List<Course> saveAll(List<Course> entities) {
-    entities.forEach(
-        course -> {
-          try {
-            var field = Course.class.getDeclaredField("courseId");
-            field.setAccessible(true);
-            field.set(course, sequence++);
-          } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new RuntimeException(e);
-          }
-        });
+    entities.forEach(course -> ReflectionTestUtils.setField(course, "courseId", sequence++));
     store.addAll(entities);
     return entities;
   }

--- a/src/test/java/edu/handong/csee/histudy/service/repository/fake/FakeStudyApplicationRepository.java
+++ b/src/test/java/edu/handong/csee/histudy/service/repository/fake/FakeStudyApplicationRepository.java
@@ -8,10 +8,12 @@ import edu.handong.csee.histudy.repository.StudyApplicantRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.test.util.ReflectionTestUtils;
 
 public class FakeStudyApplicationRepository implements StudyApplicantRepository {
 
   private final List<StudyApplicant> store = new ArrayList<>();
+  private Long sequence = 1L;
 
   @Override
   public Optional<StudyApplicant> findByUserAndTerm(User applicant, AcademicTerm currentTerm) {
@@ -46,6 +48,7 @@ public class FakeStudyApplicationRepository implements StudyApplicantRepository 
 
   @Override
   public StudyApplicant save(StudyApplicant entity) {
+    ReflectionTestUtils.setField(entity, "studyApplicantId", sequence++);
     store.add(entity);
     return entity;
   }

--- a/src/test/java/edu/handong/csee/histudy/service/repository/fake/FakeStudyGroupRepository.java
+++ b/src/test/java/edu/handong/csee/histudy/service/repository/fake/FakeStudyGroupRepository.java
@@ -5,10 +5,12 @@ import edu.handong.csee.histudy.repository.StudyGroupRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.test.util.ReflectionTestUtils;
 
 public class FakeStudyGroupRepository implements StudyGroupRepository {
 
   private final List<StudyGroup> store = new ArrayList<>();
+  private Long sequence = 1L;
 
   @Override
   public Optional<StudyGroup> findByTagAndAcademicTerm(int tag, AcademicTerm academicTerm) {
@@ -63,6 +65,7 @@ public class FakeStudyGroupRepository implements StudyGroupRepository {
 
   @Override
   public StudyGroup save(StudyGroup entity) {
+    ReflectionTestUtils.setField(entity, "studyGroupId", sequence++);
     store.add(entity);
     return entity;
   }

--- a/src/test/java/edu/handong/csee/histudy/service/repository/fake/FakeStudyReportRepository.java
+++ b/src/test/java/edu/handong/csee/histudy/service/repository/fake/FakeStudyReportRepository.java
@@ -1,0 +1,43 @@
+package edu.handong.csee.histudy.service.repository.fake;
+
+import edu.handong.csee.histudy.domain.StudyGroup;
+import edu.handong.csee.histudy.domain.StudyReport;
+import edu.handong.csee.histudy.repository.StudyReportRepository;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class FakeStudyReportRepository implements StudyReportRepository {
+
+  private final List<StudyReport> store = new ArrayList<>();
+  private Long sequence = 1L;
+
+  @Override
+  public List<StudyReport> findAllByStudyGroupOrderByCreatedDateDesc(StudyGroup studyGroup) {
+    return store.stream()
+        .filter(r -> r.getStudyGroup().equals(studyGroup))
+        .sorted(Comparator.comparing(StudyReport::getCreatedDate).reversed())
+        .toList();
+  }
+
+  @Override
+  public Optional<StudyReport> findById(Long id) {
+    return store.stream().filter(report -> report.getStudyReportId().equals(id)).findFirst();
+  }
+
+  @Override
+  public void delete(StudyReport report) {
+    store.removeIf(r -> r.equals(report));
+  }
+
+  @Override
+  public StudyReport save(StudyReport report) {
+    ReflectionTestUtils.setField(report, "studyReportId", sequence++);
+    ReflectionTestUtils.setField(report, "lastModifiedDate", LocalDateTime.now());
+    store.add(report);
+    return report;
+  }
+}

--- a/src/test/java/edu/handong/csee/histudy/service/repository/fake/FakeUserRepository.java
+++ b/src/test/java/edu/handong/csee/histudy/service/repository/fake/FakeUserRepository.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.Sort;
+import org.springframework.test.util.ReflectionTestUtils;
 
 public class FakeUserRepository implements UserRepository {
 
@@ -73,13 +74,7 @@ public class FakeUserRepository implements UserRepository {
 
   @Override
   public User save(User user) {
-    try {
-      var field = User.class.getDeclaredField("userId");
-      field.setAccessible(true);
-      field.set(user, sequence++);
-    } catch (NoSuchFieldException | IllegalAccessException e) {
-      throw new RuntimeException("Failed to set userId via reflection", e);
-    }
+    ReflectionTestUtils.setField(user, "userId", sequence++);
     store.add(user);
     return user;
   }


### PR DESCRIPTION
### 요약
- 스터디 보고서 관련 테스트 업데이트
- 내 그룹 확인 테스트 추가

### 노트
일부 서비스 메서드에서 DTO를 반환하는 과정에서 JPA를 통해 값이 설정되는 ID 속성을 사용하고 있습니다. 테스트 환경에서는 해당 ID 필드에 값을 설정하기 위해 리플렉션을 사용해 할당하는 로직을 추가했습니다.

### 이슈
#156 