### PR TITLE
활동 지표 조회 API 추가

### DIFF
--- a/src/main/java/edu/handong/csee/histudy/controller/PublicController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/PublicController.java
@@ -1,12 +1,15 @@
 package edu.handong.csee.histudy.controller;
 
+import edu.handong.csee.histudy.dto.ActivityMetricsDto;
 import edu.handong.csee.histudy.dto.TeamRankDto;
+import edu.handong.csee.histudy.service.ActivityMetricsService;
 import edu.handong.csee.histudy.service.TeamService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "공개 API")
@@ -16,10 +19,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class PublicController {
 
   private final TeamService teamService;
+  private final ActivityMetricsService activityMetricsService;
 
   @Operation(summary = "그룹 목록 조회")
   @GetMapping("/teams")
   public TeamRankDto getTeams() {
     return teamService.getAllTeams();
+  }
+
+  @Operation(summary = "활동 지표 조회")
+  @GetMapping("/activity")
+  public ActivityMetricsDto getActivityMetrics(@RequestParam(defaultValue = "all") String term) {
+    return activityMetricsService.getActivityMetrics(term);
   }
 }

--- a/src/main/java/edu/handong/csee/histudy/dto/ActivityMetricsDto.java
+++ b/src/main/java/edu/handong/csee/histudy/dto/ActivityMetricsDto.java
@@ -1,0 +1,22 @@
+package edu.handong.csee.histudy.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ActivityMetricsDto {
+
+  @Schema(description = "Total number of study members", example = "50")
+  private final long studyMembers;
+
+  @Schema(description = "Total number of study groups", example = "10")
+  private final long studyGroups;
+
+  @Schema(description = "Total study hours across all groups", example = "120")
+  private final long studyHours;
+
+  @Schema(description = "Total number of study reports submitted", example = "35")
+  private final long reports;
+}

--- a/src/main/java/edu/handong/csee/histudy/repository/StudyGroupRepository.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/StudyGroupRepository.java
@@ -24,4 +24,8 @@ public interface StudyGroupRepository {
   Optional<StudyGroup> findById(Long id);
 
   StudyGroup save(StudyGroup entity);
+
+  long count();
+
+  long countByAcademicTerm(AcademicTerm academicTerm);
 }

--- a/src/main/java/edu/handong/csee/histudy/repository/StudyReportRepository.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/StudyReportRepository.java
@@ -1,5 +1,6 @@
 package edu.handong.csee.histudy.repository;
 
+import edu.handong.csee.histudy.domain.AcademicTerm;
 import edu.handong.csee.histudy.domain.StudyGroup;
 import edu.handong.csee.histudy.domain.StudyReport;
 import java.util.List;
@@ -13,4 +14,12 @@ public interface StudyReportRepository {
   void delete(StudyReport report);
 
   StudyReport save(StudyReport report);
+
+  long count();
+
+  long countByStudyGroupAcademicTerm(AcademicTerm academicTerm);
+
+  long sumTotalMinutes();
+
+  long sumTotalMinutesByStudyGroupAcademicTerm(AcademicTerm academicTerm);
 }

--- a/src/main/java/edu/handong/csee/histudy/repository/UserRepository.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package edu.handong.csee.histudy.repository;
 
+import edu.handong.csee.histudy.domain.Role;
 import edu.handong.csee.histudy.domain.User;
 import java.util.List;
 import java.util.Optional;
@@ -19,4 +20,8 @@ public interface UserRepository {
   List<User> findAll(Sort sort);
 
   User save(User entity);
+
+  long countByRoleNot(Role role);
+
+  long countByRole(Role role);
 }

--- a/src/main/java/edu/handong/csee/histudy/repository/impl/StudyGroupRepositoryImpl.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/impl/StudyGroupRepositoryImpl.java
@@ -59,4 +59,14 @@ public class StudyGroupRepositoryImpl implements StudyGroupRepository {
   public StudyGroup save(StudyGroup studyGroup) {
     return repository.save(studyGroup);
   }
+
+  @Override
+  public long count() {
+    return repository.count();
+  }
+
+  @Override
+  public long countByAcademicTerm(AcademicTerm academicTerm) {
+    return repository.countByAcademicTerm(academicTerm);
+  }
 }

--- a/src/main/java/edu/handong/csee/histudy/repository/impl/StudyReportRepositoryImpl.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/impl/StudyReportRepositoryImpl.java
@@ -1,5 +1,6 @@
 package edu.handong.csee.histudy.repository.impl;
 
+import edu.handong.csee.histudy.domain.AcademicTerm;
 import edu.handong.csee.histudy.domain.StudyGroup;
 import edu.handong.csee.histudy.domain.StudyReport;
 import edu.handong.csee.histudy.repository.StudyReportRepository;
@@ -32,5 +33,25 @@ public class StudyReportRepositoryImpl implements StudyReportRepository {
   @Override
   public StudyReport save(StudyReport report) {
     return repository.save(report);
+  }
+
+  @Override
+  public long count() {
+    return repository.count();
+  }
+
+  @Override
+  public long countByStudyGroupAcademicTerm(AcademicTerm academicTerm) {
+    return repository.countByStudyGroupAcademicTerm(academicTerm);
+  }
+
+  @Override
+  public long sumTotalMinutes() {
+    return repository.sumTotalMinutes();
+  }
+
+  @Override
+  public long sumTotalMinutesByStudyGroupAcademicTerm(AcademicTerm academicTerm) {
+    return repository.sumTotalMinutesByStudyGroupAcademicTerm(academicTerm);
   }
 }

--- a/src/main/java/edu/handong/csee/histudy/repository/impl/UserRepositoryImpl.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/impl/UserRepositoryImpl.java
@@ -1,5 +1,6 @@
 package edu.handong.csee.histudy.repository.impl;
 
+import edu.handong.csee.histudy.domain.Role;
 import edu.handong.csee.histudy.domain.User;
 import edu.handong.csee.histudy.repository.UserRepository;
 import edu.handong.csee.histudy.repository.jpa.JpaUserRepository;
@@ -47,5 +48,15 @@ public class UserRepositoryImpl implements UserRepository {
   @Override
   public User save(User user) {
     return repository.save(user);
+  }
+
+  @Override
+  public long countByRoleNot(Role role) {
+    return repository.countByRoleNot(role);
+  }
+
+  @Override
+  public long countByRole(Role role) {
+    return repository.countByRole(role);
   }
 }

--- a/src/main/java/edu/handong/csee/histudy/repository/jpa/JpaStudyGroupRepository.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/jpa/JpaStudyGroupRepository.java
@@ -29,4 +29,6 @@ public interface JpaStudyGroupRepository extends JpaRepository<StudyGroup, Long>
           + "where m.user = :user and s.academicTerm = :currentTerm")
   Optional<StudyGroup> findByUserAndTerm(
       @Param("user") User user, @Param("currentTerm") AcademicTerm currentTerm);
+
+  long countByAcademicTerm(AcademicTerm academicTerm);
 }

--- a/src/main/java/edu/handong/csee/histudy/repository/jpa/JpaStudyReportRepository.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/jpa/JpaStudyReportRepository.java
@@ -1,11 +1,23 @@
 package edu.handong.csee.histudy.repository.jpa;
 
+import edu.handong.csee.histudy.domain.AcademicTerm;
 import edu.handong.csee.histudy.domain.StudyGroup;
 import edu.handong.csee.histudy.domain.StudyReport;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface JpaStudyReportRepository extends JpaRepository<StudyReport, Long> {
 
   List<StudyReport> findAllByStudyGroupOrderByCreatedDateDesc(StudyGroup studyGroup);
+
+  long countByStudyGroupAcademicTerm(AcademicTerm academicTerm);
+
+  @Query("select coalesce(sum(r.totalMinutes), 0) from StudyReport r")
+  long sumTotalMinutes();
+
+  @Query(
+      "select coalesce(sum(r.totalMinutes), 0) from StudyReport r where r.studyGroup.academicTerm = :academicTerm")
+  long sumTotalMinutesByStudyGroupAcademicTerm(@Param("academicTerm") AcademicTerm academicTerm);
 }

--- a/src/main/java/edu/handong/csee/histudy/repository/jpa/JpaUserRepository.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/jpa/JpaUserRepository.java
@@ -1,5 +1,6 @@
 package edu.handong.csee.histudy.repository.jpa;
 
+import edu.handong.csee.histudy.domain.Role;
 import edu.handong.csee.histudy.domain.User;
 import java.util.List;
 import java.util.Optional;
@@ -22,4 +23,8 @@ public interface JpaUserRepository extends JpaRepository<User, Long> {
 
   @Query("select u from User u where u.sub = ?1")
   Optional<User> findUserBySub(String sub);
+
+  long countByRoleNot(Role role);
+
+  long countByRole(Role role);
 }

--- a/src/main/java/edu/handong/csee/histudy/service/ActivityMetricsService.java
+++ b/src/main/java/edu/handong/csee/histudy/service/ActivityMetricsService.java
@@ -1,0 +1,63 @@
+package edu.handong.csee.histudy.service;
+
+import edu.handong.csee.histudy.domain.AcademicTerm;
+import edu.handong.csee.histudy.domain.Role;
+import edu.handong.csee.histudy.dto.ActivityMetricsDto;
+import edu.handong.csee.histudy.repository.AcademicTermRepository;
+import edu.handong.csee.histudy.repository.StudyGroupRepository;
+import edu.handong.csee.histudy.repository.StudyReportRepository;
+import edu.handong.csee.histudy.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ActivityMetricsService {
+
+  private final UserRepository userRepository;
+  private final StudyGroupRepository studyGroupRepository;
+  private final StudyReportRepository studyReportRepository;
+  private final AcademicTermRepository academicTermRepository;
+
+  public ActivityMetricsDto getActivityMetrics(String term) {
+    if ("current".equals(term)) {
+      return getCurrentTermActivityMetrics();
+    }
+    return getAllActivityMetrics();
+  }
+
+  private ActivityMetricsDto getAllActivityMetrics() {
+    long studyMembers = userRepository.countByRoleNot(Role.ADMIN);
+    long studyGroups = studyGroupRepository.count();
+    long totalMinutes = studyReportRepository.sumTotalMinutes();
+    long studyHours = totalMinutes / 60;
+    long reports = studyReportRepository.count();
+
+    return ActivityMetricsDto.builder()
+        .studyMembers(studyMembers)
+        .studyGroups(studyGroups)
+        .studyHours(studyHours)
+        .reports(reports)
+        .build();
+  }
+
+  private ActivityMetricsDto getCurrentTermActivityMetrics() {
+    AcademicTerm currentTerm =
+        academicTermRepository
+            .findCurrentSemester()
+            .orElseThrow(() -> new RuntimeException("Current semester not found"));
+
+    long studyMembers = userRepository.countByRole(Role.MEMBER);
+    long studyGroups = studyGroupRepository.countByAcademicTerm(currentTerm);
+    long totalMinutes = studyReportRepository.sumTotalMinutesByStudyGroupAcademicTerm(currentTerm);
+    long studyHours = totalMinutes / 60;
+    long reports = studyReportRepository.countByStudyGroupAcademicTerm(currentTerm);
+
+    return ActivityMetricsDto.builder()
+        .studyMembers(studyMembers)
+        .studyGroups(studyGroups)
+        .studyHours(studyHours)
+        .reports(reports)
+        .build();
+  }
+}

--- a/src/test/java/edu/handong/csee/histudy/controller/PublicControllerTest.java
+++ b/src/test/java/edu/handong/csee/histudy/controller/PublicControllerTest.java
@@ -4,41 +4,82 @@ import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import edu.handong.csee.histudy.dto.ActivityMetricsDto;
 import edu.handong.csee.histudy.dto.TeamRankDto;
 import edu.handong.csee.histudy.jwt.JwtProperties;
+import edu.handong.csee.histudy.service.ActivityMetricsService;
 import edu.handong.csee.histudy.service.JwtService;
 import edu.handong.csee.histudy.service.TeamService;
-import edu.handong.csee.histudy.controller.ExceptionController;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest({PublicController.class, ExceptionController.class})
 class PublicControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+  @Autowired private MockMvc mockMvc;
 
-    @MockBean
-    private TeamService teamService;
+  @MockBean private TeamService teamService;
 
-    @MockBean
-    private JwtService jwtService;
+  @MockBean private ActivityMetricsService activityMetricsService;
 
-    @MockBean
-    private JwtProperties jwtProperties;
+  @MockBean private JwtService jwtService;
 
-    @Test
-    void 공개그룹목록조회시_성공() throws Exception {
-        TeamRankDto teamRankDto = new TeamRankDto(List.of());
-        when(teamService.getAllTeams()).thenReturn(teamRankDto);
+  @MockBean private JwtProperties jwtProperties;
 
-        mockMvc.perform(get("/api/public/teams"))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType("application/json;charset=UTF-8"));
-    }
+  @Test
+  void 공개그룹목록조회시_성공() throws Exception {
+    TeamRankDto teamRankDto = new TeamRankDto(List.of());
+    when(teamService.getAllTeams()).thenReturn(teamRankDto);
+
+    mockMvc
+        .perform(get("/api/public/teams"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json;charset=UTF-8"));
+  }
+
+  @Test
+  void 활동지표조회_전체_성공() throws Exception {
+    ActivityMetricsDto expectedDto =
+        ActivityMetricsDto.builder()
+            .studyMembers(100)
+            .studyGroups(50)
+            .studyHours(200)
+            .reports(300)
+            .build();
+    when(activityMetricsService.getActivityMetrics("all")).thenReturn(expectedDto);
+
+    mockMvc
+        .perform(get("/api/public/activity"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json;charset=UTF-8"))
+        .andExpect(jsonPath("$.studyMembers").value(100))
+        .andExpect(jsonPath("$.studyGroups").value(50))
+        .andExpect(jsonPath("$.studyHours").value(200))
+        .andExpect(jsonPath("$.reports").value(300));
+  }
+
+  @Test
+  void 활동지표조회_현재학기_성공() throws Exception {
+    ActivityMetricsDto expectedDto =
+        ActivityMetricsDto.builder()
+            .studyMembers(20)
+            .studyGroups(10)
+            .studyHours(50)
+            .reports(80)
+            .build();
+    when(activityMetricsService.getActivityMetrics("current")).thenReturn(expectedDto);
+
+    mockMvc
+        .perform(get("/api/public/activity").param("term", "current"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json;charset=UTF-8"))
+        .andExpect(jsonPath("$.studyMembers").value(20))
+        .andExpect(jsonPath("$.studyGroups").value(10))
+        .andExpect(jsonPath("$.studyHours").value(50))
+        .andExpect(jsonPath("$.reports").value(80));
+  }
 }

--- a/src/test/java/edu/handong/csee/histudy/service/repository/fake/FakeStudyGroupRepository.java
+++ b/src/test/java/edu/handong/csee/histudy/service/repository/fake/FakeStudyGroupRepository.java
@@ -69,4 +69,14 @@ public class FakeStudyGroupRepository implements StudyGroupRepository {
     store.add(entity);
     return entity;
   }
+
+  @Override
+  public long count() {
+    return store.size();
+  }
+
+  @Override
+  public long countByAcademicTerm(AcademicTerm academicTerm) {
+    return store.stream().filter(e -> e.getAcademicTerm().equals(academicTerm)).count();
+  }
 }

--- a/src/test/java/edu/handong/csee/histudy/service/repository/fake/FakeStudyReportRepository.java
+++ b/src/test/java/edu/handong/csee/histudy/service/repository/fake/FakeStudyReportRepository.java
@@ -1,5 +1,6 @@
 package edu.handong.csee.histudy.service.repository.fake;
 
+import edu.handong.csee.histudy.domain.AcademicTerm;
 import edu.handong.csee.histudy.domain.StudyGroup;
 import edu.handong.csee.histudy.domain.StudyReport;
 import edu.handong.csee.histudy.repository.StudyReportRepository;
@@ -39,5 +40,30 @@ public class FakeStudyReportRepository implements StudyReportRepository {
     ReflectionTestUtils.setField(report, "lastModifiedDate", LocalDateTime.now());
     store.add(report);
     return report;
+  }
+
+  @Override
+  public long count() {
+    return store.size();
+  }
+
+  @Override
+  public long countByStudyGroupAcademicTerm(AcademicTerm academicTerm) {
+    return store.stream()
+        .filter(report -> report.getStudyGroup().getAcademicTerm().equals(academicTerm))
+        .count();
+  }
+
+  @Override
+  public long sumTotalMinutes() {
+    return store.stream().mapToLong(StudyReport::getTotalMinutes).sum();
+  }
+
+  @Override
+  public long sumTotalMinutesByStudyGroupAcademicTerm(AcademicTerm academicTerm) {
+    return store.stream()
+        .filter(report -> report.getStudyGroup().getAcademicTerm().equals(academicTerm))
+        .mapToLong(StudyReport::getTotalMinutes)
+        .sum();
   }
 }

--- a/src/test/java/edu/handong/csee/histudy/service/repository/fake/FakeUserRepository.java
+++ b/src/test/java/edu/handong/csee/histudy/service/repository/fake/FakeUserRepository.java
@@ -1,5 +1,6 @@
 package edu.handong.csee.histudy.service.repository.fake;
 
+import edu.handong.csee.histudy.domain.Role;
 import edu.handong.csee.histudy.domain.User;
 import edu.handong.csee.histudy.repository.UserRepository;
 import java.util.ArrayList;
@@ -77,5 +78,15 @@ public class FakeUserRepository implements UserRepository {
     ReflectionTestUtils.setField(user, "userId", sequence++);
     store.add(user);
     return user;
+  }
+
+  @Override
+  public long countByRoleNot(Role role) {
+    return store.stream().filter(user -> !user.getRole().equals(role)).count();
+  }
+
+  @Override
+  public long countByRole(Role role) {
+    return store.stream().filter(user -> user.getRole().equals(role)).count();
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 활동 지표를 조회할 수 있는 새로운 공개 API 엔드포인트(`/api/public/activity`)가 추가되었습니다. 학기(term)별 또는 전체 활동 지표를 확인할 수 있습니다.
  * 활동 지표에 포함되는 데이터로 스터디 멤버 수, 스터디 그룹 수, 총 학습 시간, 제출된 리포트 수가 제공됩니다.

* **테스트**
  * 활동 지표 조회 API에 대한 테스트 케이스가 추가되어, 전체 및 현재 학기별 응답을 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->