### PR TITLE
그룹 미배정 상태 변경을 할 수 없던 버그 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'edu.handong.csee'
-version = '1.3.1'
+version = '1.5.1'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/src/main/java/edu/handong/csee/histudy/repository/StudyGroupRepository.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/StudyGroupRepository.java
@@ -9,8 +9,6 @@ import java.util.Optional;
 public interface StudyGroupRepository {
   Optional<StudyGroup> findByTagAndAcademicTerm(int tag, AcademicTerm academicTerm);
 
-  void deleteEmptyGroup(AcademicTerm academicTerm);
-
   Optional<Integer> countMaxTag(AcademicTerm academicTerm);
 
   List<StudyGroup> findAllByAcademicTerm(AcademicTerm academicTerm);

--- a/src/main/java/edu/handong/csee/histudy/repository/impl/StudyGroupRepositoryImpl.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/impl/StudyGroupRepositoryImpl.java
@@ -21,11 +21,6 @@ public class StudyGroupRepositoryImpl implements StudyGroupRepository {
   }
 
   @Override
-  public void deleteEmptyGroup(AcademicTerm academicTerm) {
-    repository.deleteEmptyGroup(academicTerm);
-  }
-
-  @Override
   public Optional<Integer> countMaxTag(AcademicTerm academicTerm) {
     return repository.countMaxTag(academicTerm);
   }

--- a/src/main/java/edu/handong/csee/histudy/service/UserService.java
+++ b/src/main/java/edu/handong/csee/histudy/service/UserService.java
@@ -228,7 +228,17 @@ public class UserService {
                 applicantOr.ifPresent(
                     applicant -> {
                       applicant.leaveGroup();
-                      studyGroupRepository.deleteEmptyGroup(currentTerm);
+
+                      StudyGroup studyGroup = applicant.getStudyGroup();
+
+                      if (studyGroup != null && studyGroup.getMembers().isEmpty()) {
+                        /*
+                         TODO: Need to check there are associated reports
+                         Currently deleting a group with no members but with reports
+                         will cause FK constraint violation
+                        */
+                        studyGroupRepository.deleteById(studyGroup.getStudyGroupId());
+                      }
                     }));
   }
 

--- a/src/test/java/edu/handong/csee/histudy/repository/StudyGroupRepositoryTest.java
+++ b/src/test/java/edu/handong/csee/histudy/repository/StudyGroupRepositoryTest.java
@@ -3,7 +3,9 @@ package edu.handong.csee.histudy.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import edu.handong.csee.histudy.domain.*;
+import edu.handong.csee.histudy.repository.jpa.JpaStudyApplicantRepository;
 import edu.handong.csee.histudy.repository.jpa.JpaStudyGroupRepository;
+import edu.handong.csee.histudy.repository.jpa.JpaStudyReportRepository;
 import edu.handong.csee.histudy.support.BaseRepositoryTest;
 import edu.handong.csee.histudy.support.TestDataFactory;
 import java.util.List;
@@ -15,6 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 class StudyGroupRepositoryTest extends BaseRepositoryTest {
 
   @Autowired private JpaStudyGroupRepository studyGroupRepository;
+  @Autowired private JpaStudyReportRepository studyReportRepository;
+  @Autowired private JpaStudyApplicantRepository studyApplicantRepository;
 
   @Test
   void 태그와학기로조회시_해당스터디그룹반환() {
@@ -159,17 +163,14 @@ class StudyGroupRepositoryTest extends BaseRepositoryTest {
 
   @Test
   void 스터디그룹삭제시_삭제성공() {
-    // Given
-    StudyGroup studyGroup = TestDataFactory.createStudyGroup(1, currentTerm);
-    StudyGroup savedGroup = persistAndFlush(studyGroup);
+    StudyApplicant applicant =
+        studyApplicantRepository.save(
+            TestDataFactory.createStudyApplicant(currentTerm, user1, List.of(), List.of(course1)));
+    StudyGroup group = studyGroupRepository.save(StudyGroup.of(1, currentTerm, List.of(applicant)));
 
-    // When
-    studyGroupRepository.delete(savedGroup);
-    flushAndClear();
+    studyGroupRepository.deleteById(group.getStudyGroupId());
 
-    // Then
-    Optional<StudyGroup> deletedGroup =
-        studyGroupRepository.findByTagAndAcademicTerm(1, currentTerm);
+    Optional<StudyGroup> deletedGroup = studyGroupRepository.findById(group.getStudyGroupId());
     assertThat(deletedGroup).isEmpty();
   }
 

--- a/src/test/java/edu/handong/csee/histudy/service/repository/fake/FakeStudyGroupRepository.java
+++ b/src/test/java/edu/handong/csee/histudy/service/repository/fake/FakeStudyGroupRepository.java
@@ -20,14 +20,6 @@ public class FakeStudyGroupRepository implements StudyGroupRepository {
   }
 
   @Override
-  public void deleteEmptyGroup(AcademicTerm academicTerm) {
-    store.stream()
-        .filter(e -> e.getAcademicTerm().equals(academicTerm) && e.getMembers().isEmpty())
-        .toList()
-        .forEach(store::remove);
-  }
-
-  @Override
   public Optional<Integer> countMaxTag(AcademicTerm academicTerm) {
     return store.stream()
         .filter(e -> e.getAcademicTerm().equals(academicTerm))


### PR DESCRIPTION
- 그룹 미배정 과정에서 빈 그룹에 대해 삭제도 수행하는데, 해당 그룹을 참조하는 엔티티들이 Cascade에 의해 삭제 되지 않음
- 쿼리를 실행하는 메서드가 JPQL을 사용해 영속성 컨테스트를 bypass함
- 빈 그룹에 대해서만 쿼리를 실행하도록 조건을 추가하고 JPA에서 제공하는 메서드로 변경(`deleteById`)
---
Closes HandongSF/histudy-fe#104
[ConstraintViolationException 문제 정리](https://zionhann.tistory.com/57)