### PR TITLE
강의 목록 업로드시 기존 목록 삭제 후 처리하도록 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'edu.handong.csee'
-version = '1.5.1'
+version = '1.5.2'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/src/main/java/edu/handong/csee/histudy/controller/CourseController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/CourseController.java
@@ -49,7 +49,9 @@ public class CourseController {
       @RequestAttribute Claims claims) {
     if (Role.isAuthorized(claims, Role.ADMIN, Role.USER)) {
       List<CourseDto.CourseInfo> courses =
-          (keyword == null) ? courseService.getCurrentCourses() : courseService.search(keyword);
+          (keyword == null || keyword.isBlank())
+              ? courseService.getCurrentCourses()
+              : courseService.search(keyword);
 
       return ResponseEntity.ok(new CourseDto(courses));
     }

--- a/src/main/java/edu/handong/csee/histudy/controller/CourseController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/CourseController.java
@@ -51,7 +51,7 @@ public class CourseController {
       List<CourseDto.CourseInfo> courses =
           (keyword == null || keyword.isBlank())
               ? courseService.getCurrentCourses()
-              : courseService.search(keyword);
+              : courseService.search(keyword.trim());
 
       return ResponseEntity.ok(new CourseDto(courses));
     }

--- a/src/main/java/edu/handong/csee/histudy/controller/CourseController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/CourseController.java
@@ -5,8 +5,9 @@ import edu.handong.csee.histudy.dto.CourseDto;
 import edu.handong.csee.histudy.dto.CourseIdDto;
 import edu.handong.csee.histudy.exception.ForbiddenException;
 import edu.handong.csee.histudy.service.CourseService;
+import edu.handong.csee.histudy.util.CSVResolver;
+import edu.handong.csee.histudy.util.CourseCSV;
 import io.jsonwebtoken.Claims;
-import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -23,13 +24,13 @@ public class CourseController {
 
   @PostMapping(consumes = {"multipart/form-data"})
   public ResponseEntity<Void> importCourses(
-      @RequestParam("file") MultipartFile file, @RequestAttribute Claims claims)
-      throws IOException {
+      @RequestParam("file") MultipartFile file, @RequestAttribute Claims claims) {
     if (Role.isAuthorized(claims, Role.ADMIN)) {
       if (file.isEmpty()) {
         return ResponseEntity.status(HttpStatus.NOT_ACCEPTABLE).build();
       }
-      courseService.readCourseCSV(file);
+      List<CourseCSV> courseData = CSVResolver.of(file).resolve();
+      courseService.replaceCourses(courseData);
       return ResponseEntity.status(HttpStatus.CREATED).build();
     }
     throw new ForbiddenException();

--- a/src/main/java/edu/handong/csee/histudy/repository/CourseRepository.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/CourseRepository.java
@@ -1,5 +1,6 @@
 package edu.handong.csee.histudy.repository;
 
+import edu.handong.csee.histudy.domain.AcademicTerm;
 import edu.handong.csee.histudy.domain.Course;
 import java.util.List;
 import java.util.Optional;
@@ -14,6 +15,8 @@ public interface CourseRepository {
   boolean existsById(Long id);
 
   void deleteById(Long id);
+
+  void deleteAllByAcademicTerm(AcademicTerm academicTerm);
 
   Optional<Course> findById(Long id);
 }

--- a/src/main/java/edu/handong/csee/histudy/repository/impl/CourseRepositoryImpl.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/impl/CourseRepositoryImpl.java
@@ -1,5 +1,6 @@
 package edu.handong.csee.histudy.repository.impl;
 
+import edu.handong.csee.histudy.domain.AcademicTerm;
 import edu.handong.csee.histudy.domain.Course;
 import edu.handong.csee.histudy.repository.CourseRepository;
 import edu.handong.csee.histudy.repository.jpa.JpaCourseRepository;
@@ -36,6 +37,11 @@ public class CourseRepositoryImpl implements CourseRepository {
   @Override
   public void deleteById(Long id) {
     repository.deleteById(id);
+  }
+
+  @Override
+  public void deleteAllByAcademicTerm(AcademicTerm academicTerm) {
+    repository.deleteAllByAcademicTerm(academicTerm);
   }
 
   @Override

--- a/src/main/java/edu/handong/csee/histudy/repository/jpa/JpaCourseRepository.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/jpa/JpaCourseRepository.java
@@ -12,7 +12,7 @@ public interface JpaCourseRepository extends JpaRepository<Course, Long> {
   @Query(
       "select c from Course c "
           + "where lower(c.name) "
-          + "like lower(concat('%',:keyword,'%'))"
+          + "like lower(concat('%', :keyword, '%')) "
           + "and c.academicTerm.isCurrent = true")
   List<Course> findAllByNameContainingIgnoreCase(@Param("keyword") String keyword);
 

--- a/src/main/java/edu/handong/csee/histudy/repository/jpa/JpaCourseRepository.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/jpa/JpaCourseRepository.java
@@ -1,12 +1,22 @@
 package edu.handong.csee.histudy.repository.jpa;
 
+import edu.handong.csee.histudy.domain.AcademicTerm;
 import edu.handong.csee.histudy.domain.Course;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface JpaCourseRepository extends JpaRepository<Course, Long> {
 
-  List<Course> findAllByNameContainingIgnoreCase(String keyword);
+  @Query(
+      "select c from Course c "
+          + "where lower(c.name) "
+          + "like lower(concat('%',:keyword,'%'))"
+          + "and c.academicTerm.isCurrent = true")
+  List<Course> findAllByNameContainingIgnoreCase(@Param("keyword") String keyword);
 
   List<Course> findAllByAcademicTermIsCurrentTrue();
+
+  void deleteAllByAcademicTerm(AcademicTerm academicTerm);
 }

--- a/src/main/java/edu/handong/csee/histudy/service/CourseService.java
+++ b/src/main/java/edu/handong/csee/histudy/service/CourseService.java
@@ -31,10 +31,12 @@ public class CourseService {
 
     AcademicTerm currentTerm =
         academicTermRepository.findCurrentSemester().orElseThrow(NoCurrentTermFoundException::new);
-    courseRepository.deleteAllByAcademicTerm(currentTerm);
-
     List<Course> courses = toCourses(courseData, currentTerm);
-    courseRepository.saveAll(courses);
+
+    if (!courses.isEmpty()) {
+      courseRepository.deleteAllByAcademicTerm(currentTerm);
+      courseRepository.saveAll(courses);
+    }
   }
 
   private List<Course> toCourses(List<CourseCSV> courseData, AcademicTerm currentTerm) {

--- a/src/main/java/edu/handong/csee/histudy/util/CSVResolver.java
+++ b/src/main/java/edu/handong/csee/histudy/util/CSVResolver.java
@@ -11,20 +11,20 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.io.input.BOMInputStream;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 public class CSVResolver {
 
   private final List<CSVRecord> records;
 
-  public static CSVResolver of(InputStream in) {
-    try {
+  public static CSVResolver of(MultipartFile file) {
+    try (InputStream in = file.getInputStream()) {
       Reader reader =
           new InputStreamReader(
               new BOMInputStream.Builder().setInputStream(in).get(), StandardCharsets.UTF_8);
       CSVFormat format =
           CSVFormat.Builder.create(CSVFormat.DEFAULT).setHeader().setSkipHeaderRecord(true).build();
-
       CSVParser parser = CSVParser.parse(reader, format);
       CSVResolver resolver = new CSVResolver(parser.getRecords());
 
@@ -36,7 +36,7 @@ public class CSVResolver {
     }
   }
 
-  public List<CourseCSV> createCourseCSV() {
+  public List<CourseCSV> resolve() {
     return records.stream().map(CourseCSV::of).toList();
   }
 }

--- a/src/main/java/edu/handong/csee/histudy/util/CSVResolver.java
+++ b/src/main/java/edu/handong/csee/histudy/util/CSVResolver.java
@@ -19,18 +19,18 @@ public class CSVResolver {
   private final List<CSVRecord> records;
 
   public static CSVResolver of(MultipartFile file) {
-    try (InputStream in = file.getInputStream()) {
-      Reader reader =
-          new InputStreamReader(
-              new BOMInputStream.Builder().setInputStream(in).get(), StandardCharsets.UTF_8);
-      CSVFormat format =
-          CSVFormat.Builder.create(CSVFormat.DEFAULT).setHeader().setSkipHeaderRecord(true).build();
-      CSVParser parser = CSVParser.parse(reader, format);
-      CSVResolver resolver = new CSVResolver(parser.getRecords());
-
-      parser.close();
-      reader.close();
-      return resolver;
+    try (InputStream in = file.getInputStream();
+        Reader reader =
+            new InputStreamReader(
+                new BOMInputStream.Builder().setInputStream(in).get(), StandardCharsets.UTF_8);
+        CSVParser parser =
+            CSVParser.parse(
+                reader,
+                CSVFormat.Builder.create(CSVFormat.DEFAULT)
+                    .setHeader()
+                    .setSkipHeaderRecord(true)
+                    .build())) {
+      return new CSVResolver(parser.getRecords());
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/src/main/java/edu/handong/csee/histudy/util/CourseCSV.java
+++ b/src/main/java/edu/handong/csee/histudy/util/CourseCSV.java
@@ -2,38 +2,29 @@ package edu.handong.csee.histudy.util;
 
 import edu.handong.csee.histudy.domain.AcademicTerm;
 import edu.handong.csee.histudy.domain.Course;
-import edu.handong.csee.histudy.domain.TermType;
 import lombok.Builder;
 import org.apache.commons.csv.CSVRecord;
 
 @Builder
 public class CourseCSV {
-  private String clazz;
+  private String title;
   private String code;
   private String professor;
-  private int year;
-  private int semester;
 
   public static CourseCSV of(CSVRecord record) {
     return CourseCSV.builder()
-        .clazz(record.get("class"))
+        .title(record.get("title"))
         .code(record.get("code"))
-        .professor(record.get("professor"))
-        .year(Integer.parseInt(record.get("year")))
-        .semester(Integer.parseInt(record.get("semester")))
+        .professor(record.get("prof"))
         .build();
   }
 
   public Course toCourse(AcademicTerm academicTerm) {
     return Course.builder()
-        .name(clazz)
+        .name(title)
         .code(code)
         .professor(professor)
         .academicTerm(academicTerm)
         .build();
-  }
-
-  public AcademicTerm toAcademicTerm() {
-    return AcademicTerm.builder().academicYear(year).semester(TermType.parse(semester)).build();
   }
 }

--- a/src/main/java/edu/handong/csee/histudy/util/CourseCSV.java
+++ b/src/main/java/edu/handong/csee/histudy/util/CourseCSV.java
@@ -12,11 +12,20 @@ public class CourseCSV {
   private String professor;
 
   public static CourseCSV of(CSVRecord record) {
-    return CourseCSV.builder()
-        .title(record.get("title"))
-        .code(record.get("code"))
-        .professor(record.get("prof"))
-        .build();
+    String title = validateAndTrim(record.get("title"), "title", record.getRecordNumber());
+    String code = validateAndTrim(record.get("code"), "code", record.getRecordNumber());
+    String professor = validateAndTrim(record.get("prof"), "prof", record.getRecordNumber());
+
+    return CourseCSV.builder().title(title).code(code).professor(professor).build();
+  }
+
+  private static String validateAndTrim(String value, String fieldName, long recordNumber) {
+    String trimmed = value != null ? value.trim() : null;
+    if (trimmed == null || trimmed.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Missing or empty required field '" + fieldName + "' in CSV record " + recordNumber);
+    }
+    return trimmed;
   }
 
   public Course toCourse(AcademicTerm academicTerm) {

--- a/src/test/java/edu/handong/csee/histudy/controller/CourseControllerTest.java
+++ b/src/test/java/edu/handong/csee/histudy/controller/CourseControllerTest.java
@@ -149,6 +149,24 @@ class CourseControllerTest {
   }
 
   @Test
+  void 사용자가_앞뒤공백포함_검색어로_강의목록조회시_트림처리후_검색() throws Exception {
+    Claims claims = mock(Claims.class);
+    when(claims.getSubject()).thenReturn("user@test.com");
+    when(claims.get("rol", String.class)).thenReturn(Role.USER.name());
+
+    List<CourseDto.CourseInfo> courses = List.of();
+    when(courseService.search(anyString())).thenReturn(courses);
+
+    mockMvc
+        .perform(get("/api/courses").requestAttr("claims", claims).param("search", "  java  "))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"));
+
+    verify(courseService).search("java");
+    verify(courseService, never()).getCurrentCourses();
+  }
+
+  @Test
   void 권한없는사용자가_강의업로드시_실패() throws Exception {
     Claims claims = mock(Claims.class);
     when(claims.getSubject()).thenReturn("user@test.com");

--- a/src/test/java/edu/handong/csee/histudy/controller/CourseControllerTest.java
+++ b/src/test/java/edu/handong/csee/histudy/controller/CourseControllerTest.java
@@ -60,7 +60,7 @@ class CourseControllerTest {
     MockMultipartFile file =
         new MockMultipartFile("file", "courses.csv", "text/csv", "course content".getBytes());
 
-    doNothing().when(courseService).readCourseCSV(any());
+    doNothing().when(courseService).replaceCourses(any());
 
     mockMvc
         .perform(multipart("/api/courses").file(file).requestAttr("claims", claims))

--- a/src/test/java/edu/handong/csee/histudy/controller/CourseControllerTest.java
+++ b/src/test/java/edu/handong/csee/histudy/controller/CourseControllerTest.java
@@ -131,6 +131,24 @@ class CourseControllerTest {
   }
 
   @Test
+  void 사용자가_빈검색어로_강의목록조회시_현재강의목록_반환() throws Exception {
+    Claims claims = mock(Claims.class);
+    when(claims.getSubject()).thenReturn("user@test.com");
+    when(claims.get("rol", String.class)).thenReturn(Role.USER.name());
+
+    List<CourseDto.CourseInfo> currentCourses = List.of();
+    when(courseService.getCurrentCourses()).thenReturn(currentCourses);
+
+    mockMvc
+        .perform(get("/api/courses").requestAttr("claims", claims).param("search", ""))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"));
+
+    verify(courseService).getCurrentCourses();
+    verify(courseService, never()).search(anyString());
+  }
+
+  @Test
   void 권한없는사용자가_강의업로드시_실패() throws Exception {
     Claims claims = mock(Claims.class);
     when(claims.getSubject()).thenReturn("user@test.com");

--- a/src/test/java/edu/handong/csee/histudy/service/CourseServiceTest.java
+++ b/src/test/java/edu/handong/csee/histudy/service/CourseServiceTest.java
@@ -35,11 +35,7 @@ public class CourseServiceTest {
 
     courseService =
         new CourseService(
-            courseRepository,
-            userRepository,
-            academicTermRepository,
-            studyGroupRepository,
-            studyApplicantRepository);
+            courseRepository, userRepository, academicTermRepository, studyGroupRepository);
 
     AcademicTerm term = TestDataFactory.createCurrentTerm();
     academicTermRepository.save(term);
@@ -94,6 +90,40 @@ public class CourseServiceTest {
   }
 
   @Test
+  void 대소문자_키워드제공시_대소문자무관_검색() {
+    // When
+    String keyword1 = "ALGO"; // uppercase
+    String keyword2 = "Algorithm"; // mixed case
+    String keyword3 = "algorithms"; // lowercase with plural
+
+    List<CourseDto.CourseInfo> res1 = courseService.search(keyword1);
+    List<CourseDto.CourseInfo> res2 = courseService.search(keyword2);
+    List<CourseDto.CourseInfo> res3 = courseService.search(keyword3);
+
+    // Then
+    assertThat(res1.size()).isEqualTo(1); // Should match "Introduction to Algorithms"
+    assertThat(res2.size()).isEqualTo(1); // Should match "Introduction to Algorithms"
+    assertThat(res3.size()).isEqualTo(1); // Should match "Introduction to Algorithms"
+  }
+
+  @Test
+  void 다양한대소문자_패턴검색() {
+    // When
+    String keyword1 = "data"; // lowercase
+    String keyword2 = "DATA"; // uppercase
+    String keyword3 = "Data"; // title case
+
+    List<CourseDto.CourseInfo> res1 = courseService.search(keyword1);
+    List<CourseDto.CourseInfo> res2 = courseService.search(keyword2);
+    List<CourseDto.CourseInfo> res3 = courseService.search(keyword3);
+
+    // Then - All should match "Introduction to Data Structures"
+    assertThat(res1.size()).isEqualTo(1);
+    assertThat(res2.size()).isEqualTo(1);
+    assertThat(res3.size()).isEqualTo(1);
+  }
+
+  @Test
   void 사용자이메일시_팀강의목록반환() {
     // When
     List<CourseDto.CourseInfo> res = courseService.getTeamCourses("user1@test.com");
@@ -103,33 +133,14 @@ public class CourseServiceTest {
   }
 
   @Test
-  void CSV파일제공시_강의저장() throws IOException {
-    // Given
-    String content =
-        """
-    class,code,professor,year,semester
-    Introduction to Test,ECE00103,John,2025,1
-    """;
-    InputStream stream = new ByteArrayInputStream(content.getBytes());
-    MockMultipartFile file = new MockMultipartFile("file", stream);
-
-    // When
-    courseService.readCourseCSV(file);
-
-    // Then
-    List<Course> list = courseRepository.findAllByAcademicTermIsCurrentTrue();
-    assertThat(list.size()).isEqualTo(3);
-  }
-
-  @Test
   void 유효한CSV파일시_강의저장성공() throws IOException {
     // Given
     String csvContent =
         """
-    class,code,professor,year,semester
-    Advanced Programming,CSE30201,Dr. Kim,2025,1
-    Database Systems,CSE30301,Prof. Lee,2025,1
-    Operating Systems,CSE30401,Dr. Park,2025,2
+    title,code,prof
+    Advanced Programming,CSE30201,Dr. Kim
+    Database Systems,CSE30301,Prof. Lee
+    Operating Systems,CSE30401,Dr. Park
     """;
     InputStream stream = new ByteArrayInputStream(csvContent.getBytes());
     MockMultipartFile file =
@@ -140,37 +151,7 @@ public class CourseServiceTest {
 
     // Then
     List<Course> savedCourses = ((FakeCourseRepository) courseRepository).findAll();
-    assertThat(savedCourses).hasSize(5); // 2 existing + 3 new
-
-    Course newCourse1 =
-        savedCourses.stream().filter(c -> c.getCode().equals("CSE30201")).findFirst().orElseThrow();
-    assertThat(newCourse1.getName()).isEqualTo("Advanced Programming");
-    assertThat(newCourse1.getProfessor()).isEqualTo("Dr. Kim");
-    assertThat(newCourse1.getAcademicTerm().getAcademicYear()).isEqualTo(2025);
-  }
-
-  @Test
-  void 새학기데이터시_학기생성() throws IOException {
-    // Given
-    String csvContent =
-        """
-    class,code,professor,year,semester
-    New Course,NEW001,New Prof,2026,1
-    """;
-    InputStream stream = new ByteArrayInputStream(csvContent.getBytes());
-    MockMultipartFile file =
-        new MockMultipartFile("courses.csv", "courses.csv", "text/csv", stream);
-
-    // When
-    courseService.readCourseCSV(file);
-
-    // Then
-    List<AcademicTerm> terms = ((FakeAcademicTermRepository) academicTermRepository).findAll();
-    assertThat(terms).hasSize(2); // 1 existing + 1 new
-
-    AcademicTerm newTerm =
-        terms.stream().filter(t -> t.getAcademicYear() == 2026).findFirst().orElseThrow();
-    assertThat(newTerm.getSemester()).isEqualTo(TermType.SPRING);
+    assertThat(savedCourses).hasSize(3); // 3 new courses (existing current courses deleted)
   }
 
   @Test

--- a/src/test/java/edu/handong/csee/histudy/service/CourseServiceTest.java
+++ b/src/test/java/edu/handong/csee/histudy/service/CourseServiceTest.java
@@ -7,7 +7,8 @@ import edu.handong.csee.histudy.dto.CourseDto;
 import edu.handong.csee.histudy.repository.*;
 import edu.handong.csee.histudy.service.repository.fake.*;
 import edu.handong.csee.histudy.support.TestDataFactory;
-import java.io.ByteArrayInputStream;
+import edu.handong.csee.histudy.util.CSVResolver;
+import edu.handong.csee.histudy.util.CourseCSV;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -142,12 +143,12 @@ public class CourseServiceTest {
     Database Systems,CSE30301,Prof. Lee
     Operating Systems,CSE30401,Dr. Park
     """;
-    InputStream stream = new ByteArrayInputStream(csvContent.getBytes());
     MockMultipartFile file =
-        new MockMultipartFile("courses.csv", "courses.csv", "text/csv", stream);
+        new MockMultipartFile("courses.csv", "courses.csv", "text/csv", csvContent.getBytes());
 
     // When
-    courseService.readCourseCSV(file);
+    List<CourseCSV> courseData = CSVResolver.of(file).resolve();
+    courseService.replaceCourses(courseData);
 
     // Then
     List<Course> savedCourses = ((FakeCourseRepository) courseRepository).findAll();
@@ -166,9 +167,9 @@ public class CourseServiceTest {
         };
 
     // When & Then
-    assertThatThrownBy(() -> courseService.readCourseCSV(file))
-        .isInstanceOf(IOException.class)
-        .hasMessage("File read error");
+    assertThatThrownBy(() -> CSVResolver.of(file).resolve())
+        .isInstanceOf(RuntimeException.class)
+        .hasCauseInstanceOf(IOException.class);
   }
 
   @Test
@@ -181,12 +182,11 @@ public class CourseServiceTest {
     ,CSE30301,Prof. Lee
     Operating Systems,,Dr. Park
     """;
-    InputStream stream = new ByteArrayInputStream(csvContent.getBytes());
     MockMultipartFile file =
-        new MockMultipartFile("courses.csv", "courses.csv", "text/csv", stream);
+        new MockMultipartFile("courses.csv", "courses.csv", "text/csv", csvContent.getBytes());
 
     // When & Then
-    assertThatThrownBy(() -> courseService.readCourseCSV(file))
+    assertThatThrownBy(() -> CSVResolver.of(file).resolve())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Missing or empty required field");
   }
@@ -200,12 +200,11 @@ public class CourseServiceTest {
     Advanced Programming,CSE30201,Dr. Kim
     Database Systems,   ,Prof. Lee
     """;
-    InputStream stream = new ByteArrayInputStream(csvContent.getBytes());
     MockMultipartFile file =
-        new MockMultipartFile("courses.csv", "courses.csv", "text/csv", stream);
+        new MockMultipartFile("courses.csv", "courses.csv", "text/csv", csvContent.getBytes());
 
     // When & Then
-    assertThatThrownBy(() -> courseService.readCourseCSV(file))
+    assertThatThrownBy(() -> CSVResolver.of(file).resolve())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Missing or empty required field 'code'");
   }
@@ -218,12 +217,12 @@ public class CourseServiceTest {
     title,code,prof
       Advanced Programming  ,  CSE30201  ,  Dr. Kim
     """;
-    InputStream stream = new ByteArrayInputStream(csvContent.getBytes());
     MockMultipartFile file =
-        new MockMultipartFile("courses.csv", "courses.csv", "text/csv", stream);
+        new MockMultipartFile("courses.csv", "courses.csv", "text/csv", csvContent.getBytes());
 
     // When
-    courseService.readCourseCSV(file);
+    List<CourseCSV> courseData = CSVResolver.of(file).resolve();
+    courseService.replaceCourses(courseData);
 
     // Then
     List<Course> savedCourses = ((FakeCourseRepository) courseRepository).findAll();

--- a/src/test/java/edu/handong/csee/histudy/service/repository/fake/FakeCourseRepository.java
+++ b/src/test/java/edu/handong/csee/histudy/service/repository/fake/FakeCourseRepository.java
@@ -1,5 +1,6 @@
 package edu.handong.csee.histudy.service.repository.fake;
 
+import edu.handong.csee.histudy.domain.AcademicTerm;
 import edu.handong.csee.histudy.domain.Course;
 import edu.handong.csee.histudy.repository.CourseRepository;
 import java.util.ArrayList;
@@ -16,7 +17,7 @@ public class FakeCourseRepository implements CourseRepository {
   @Override
   public List<Course> findAllByNameContainingIgnoreCase(String keyword) {
     return store.stream()
-        .filter(course -> course.getName().toLowerCase().contains(keyword))
+        .filter(course -> course.getName().toLowerCase().contains(keyword.toLowerCase()))
         .collect(Collectors.toList());
   }
 
@@ -40,6 +41,11 @@ public class FakeCourseRepository implements CourseRepository {
   @Override
   public void deleteById(Long id) {
     store.removeIf(c -> c.getCourseId().equals(id));
+  }
+
+  @Override
+  public void deleteAllByAcademicTerm(AcademicTerm academicTerm) {
+    store.removeIf(c -> c.getAcademicTerm().equals(academicTerm));
   }
 
   @Override


### PR DESCRIPTION
- 강의 목록을 불러올 때 쿼리 파라미터가 빈 문자열인 경우를 현재 학기의 강의 목록을 불러오도록 수정
  > 기존에 쿼리 파라미터가 `null`, 즉 파라미터가 붙지 않는 경우에 대해 분기 처리를 하고 있었으나, 클라이언트에서는 기본적으로 쿼리 파라미터 Key를 붙여서 요청을 보내기 때문에 `null` 이 아닌 빈 문자열이 바인딩 되어 의도하지 않은 결과가 반환되었습니다. 따라서 빈 문자열인 경우에 대한 분기 처리를 추가하고, 쿼리에서 현재 학기로 조건을 설정했습니다.

    > <img width="351" height="96" alt="Screenshot 2025-09-14 at 18 49 17" src="https://github.com/user-attachments/assets/c94e6694-4554-4912-a1ec-c134a05e246a" />

- CSV 파일을 통해 강의 목록 업로드시 기존에 현재 학기에 등록된 강의 목록을 삭제하고 업로드하도록 변경
- CSV 파일 양식 변경

  > 기존에는 CSV 파일에 학기 정보 헤더가 있어 (이론적으로) 서로 다른 학기의 강의를 한번에 등록하는 것이 가능했습니다. 이 경우 업로드 전에 등록된 강의 목록을 삭제할 때 "언제" 등록된 강의를 삭제할 것인지 파악하는 것이 매우 모호해졌습니다. 새 학기 스터디 그룹 신청을 받기 위해 강의 목록을 등록하는 맥락을 고려할 때, 과거 학기의 강의를 등록한다는 것은 실용적이지 않습니다. 따라서 현재 학기에 등록하는 것으로 전제하고 CSV 헤더에서 관련 헤더를 제거하여 간소화했습니다.

  - `code` -> `code` (유지)
  - `class` -> `title`
  - `professor` -> `prof`
  - `year`, `semester` 헤더 삭제

---

Closes #182 