### PR TITLE
그룹 멤버 변경시 공통 과목이 올바르게 갱신되지 않는 버그 수정 외

### DIFF
--- a/api-docs.yaml
+++ b/api-docs.yaml
@@ -610,27 +610,6 @@ paths:
             '*/*':
               schema:
                 $ref: '#/components/schemas/TeamReportDto'
-  /api/admin/group:
-    delete:
-      tags:
-        - 관리자 API
-      summary: 그룹 삭제
-      operationId: deleteTeam
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TeamIdDto'
-        required: true
-      responses:
-        '200':
-          description: OK
-          content:
-            '*/*':
-              schema:
-                type: integer
-                format: int32
-      deprecated: true
   /api/admin/academicTerm:
     post:
       tags:

--- a/src/main/java/edu/handong/csee/histudy/controller/AdminController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/AdminController.java
@@ -4,7 +4,6 @@ import edu.handong.csee.histudy.controller.form.AcademicTermForm;
 import edu.handong.csee.histudy.domain.Role;
 import edu.handong.csee.histudy.dto.AcademicTermDto;
 import edu.handong.csee.histudy.dto.TeamDto;
-import edu.handong.csee.histudy.dto.TeamIdDto;
 import edu.handong.csee.histudy.dto.TeamReportDto;
 import edu.handong.csee.histudy.dto.UserDto;
 import edu.handong.csee.histudy.exception.ForbiddenException;
@@ -31,16 +30,6 @@ public class AdminController {
     if (Role.isAuthorized(claims, Role.ADMIN)) {
       String email = claims.getSubject();
       return ResponseEntity.ok(teamService.getTeams(email));
-    }
-    throw new ForbiddenException();
-  }
-
-  @Deprecated
-  @DeleteMapping("/group")
-  public ResponseEntity<Integer> deleteTeam(
-      @RequestBody TeamIdDto dto, @RequestAttribute Claims claims) {
-    if (Role.isAuthorized(claims, Role.ADMIN)) {
-      return ResponseEntity.ok(teamService.deleteTeam(dto, claims.getSubject()));
     }
     throw new ForbiddenException();
   }

--- a/src/main/java/edu/handong/csee/histudy/domain/GroupCourse.java
+++ b/src/main/java/edu/handong/csee/histudy/domain/GroupCourse.java
@@ -25,7 +25,5 @@ public class GroupCourse extends BaseTime {
   public GroupCourse(StudyGroup studyGroup, Course course) {
     this.studyGroup = studyGroup;
     this.course = course;
-
-    studyGroup.getCourses().add(this);
   }
 }

--- a/src/main/java/edu/handong/csee/histudy/domain/StudyApplicant.java
+++ b/src/main/java/edu/handong/csee/histudy/domain/StudyApplicant.java
@@ -67,11 +67,14 @@ public class StudyApplicant extends BaseTime {
   }
 
   public void joinStudyGroup(StudyGroup studyGroup) {
-    if (hasStudyGroup()) {
+    if (hasStudyGroup() && !this.studyGroup.equals(studyGroup)) {
       leaveStudyGroup();
     }
     this.studyGroup = studyGroup;
-    studyGroup.getMembers().add(this);
+
+    if (!studyGroup.getMembers().contains(this)) {
+      studyGroup.getMembers().add(this);
+    }
   }
 
   public void leaveStudyGroup() {

--- a/src/main/java/edu/handong/csee/histudy/domain/StudyApplicant.java
+++ b/src/main/java/edu/handong/csee/histudy/domain/StudyApplicant.java
@@ -26,7 +26,7 @@ public class StudyApplicant extends BaseTime {
   @JoinColumn(name = "user_id")
   private User user;
 
-  @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "study_group_id")
   private StudyGroup studyGroup;
 

--- a/src/main/java/edu/handong/csee/histudy/repository/StudyGroupRepository.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/StudyGroupRepository.java
@@ -15,13 +15,13 @@ public interface StudyGroupRepository {
 
   Optional<StudyGroup> findByUserAndTerm(User user, AcademicTerm currentTerm);
 
-  boolean existsById(Long id);
-
   void deleteById(Long id);
 
   Optional<StudyGroup> findById(Long id);
 
   StudyGroup save(StudyGroup entity);
+
+  List<StudyGroup> saveAll(Iterable<StudyGroup> entities);
 
   long count();
 

--- a/src/main/java/edu/handong/csee/histudy/repository/impl/StudyGroupRepositoryImpl.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/impl/StudyGroupRepositoryImpl.java
@@ -36,11 +36,6 @@ public class StudyGroupRepositoryImpl implements StudyGroupRepository {
   }
 
   @Override
-  public boolean existsById(Long id) {
-    return repository.existsById(id);
-  }
-
-  @Override
   public void deleteById(Long id) {
     repository.deleteById(id);
   }
@@ -53,6 +48,11 @@ public class StudyGroupRepositoryImpl implements StudyGroupRepository {
   @Override
   public StudyGroup save(StudyGroup studyGroup) {
     return repository.save(studyGroup);
+  }
+
+  @Override
+  public List<StudyGroup> saveAll(Iterable<StudyGroup> entities) {
+    return repository.saveAll(entities);
   }
 
   @Override

--- a/src/main/java/edu/handong/csee/histudy/service/TeamService.java
+++ b/src/main/java/edu/handong/csee/histudy/service/TeamService.java
@@ -49,14 +49,6 @@ public class TeamService {
         .toList();
   }
 
-  public int deleteTeam(TeamIdDto dto, String email) {
-    if (studyGroupRepository.existsById(dto.getGroupId())) {
-      studyGroupRepository.deleteById(dto.getGroupId());
-      return 1;
-    }
-    return 0;
-  }
-
   public TeamReportDto getTeamReports(long id, String email) {
     StudyGroup studyGroup = studyGroupRepository.findById(id).orElseThrow();
     List<UserDto.UserBasic> users =

--- a/src/main/java/edu/handong/csee/histudy/service/UserService.java
+++ b/src/main/java/edu/handong/csee/histudy/service/UserService.java
@@ -221,8 +221,11 @@ public class UserService {
               studyGroupRepository
                   .findByTagAndAcademicTerm(tag, currentTerm)
                   .ifPresentOrElse(
-                      group -> group.assignMembers(applicant),
-                      () -> StudyGroup.of(tag, currentTerm, List.of(applicant)));
+                      existingGroup -> existingGroup.assignMembers(applicant),
+                      () -> {
+                        StudyGroup newGroup = StudyGroup.of(tag, currentTerm, List.of(applicant));
+                        studyGroupRepository.save(newGroup);
+                      });
             },
             () ->
                 applicantOr.ifPresent(

--- a/src/test/java/edu/handong/csee/histudy/controller/AdminControllerTest.java
+++ b/src/test/java/edu/handong/csee/histudy/controller/AdminControllerTest.java
@@ -12,7 +12,6 @@ import edu.handong.csee.histudy.domain.Role;
 import edu.handong.csee.histudy.domain.TermType;
 import edu.handong.csee.histudy.dto.AcademicTermDto;
 import edu.handong.csee.histudy.dto.TeamDto;
-import edu.handong.csee.histudy.dto.TeamIdDto;
 import edu.handong.csee.histudy.dto.TeamReportDto;
 import edu.handong.csee.histudy.dto.UserDto;
 import edu.handong.csee.histudy.interceptor.AuthenticationInterceptor;
@@ -77,25 +76,6 @@ class AdminControllerTest {
         .perform(get("/api/admin/manageGroup").requestAttr("claims", claims))
         .andExpect(status().isOk())
         .andExpect(content().contentType("application/json"));
-  }
-
-  @Test
-  void 관리자가_그룹삭제시_성공() throws Exception {
-    Claims claims = mock(Claims.class);
-    when(claims.getSubject()).thenReturn("admin@test.com");
-    when(claims.get("rol", String.class)).thenReturn(Role.ADMIN.name());
-
-    TeamIdDto dto = mock(TeamIdDto.class);
-    when(teamService.deleteTeam(any(TeamIdDto.class), anyString())).thenReturn(1);
-
-    mockMvc
-        .perform(
-            delete("/api/admin/group")
-                .requestAttr("claims", claims)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .content(objectMapper.writeValueAsString(dto)))
-        .andExpect(status().isOk())
-        .andExpect(content().string("1"));
   }
 
   @Test

--- a/src/test/java/edu/handong/csee/histudy/repository/AcademicTermRepositoryTest.java
+++ b/src/test/java/edu/handong/csee/histudy/repository/AcademicTermRepositoryTest.java
@@ -33,7 +33,7 @@ class AcademicTermRepositoryTest extends BaseRepositoryTest {
             .semester(TermType.WINTER)
             .isCurrent(false)
             .build();
-    persistAndFlush(testTerm);
+    academicTermRepository.save(testTerm);
 
     // When
     Optional<AcademicTerm> result = academicTermRepository.findByYearAndTerm(2020, TermType.WINTER);

--- a/src/test/java/edu/handong/csee/histudy/repository/CourseRepositoryTest.java
+++ b/src/test/java/edu/handong/csee/histudy/repository/CourseRepositoryTest.java
@@ -41,9 +41,9 @@ class CourseRepositoryTest extends BaseRepositoryTest {
             .academicTerm(currentTerm)
             .build();
 
-    persistAndFlush(course1);
-    persistAndFlush(course2);
-    persistAndFlush(course3);
+    courseRepository.save(course1);
+    courseRepository.save(course2);
+    courseRepository.save(course3);
 
     // When
     List<Course> results = courseRepository.findAllByNameContainingIgnoreCase("programming");
@@ -66,7 +66,7 @@ class CourseRepositoryTest extends BaseRepositoryTest {
             .academicTerm(currentTerm)
             .build();
 
-    persistAndFlush(course);
+    courseRepository.save(course);
 
     // When
     List<Course> results = courseRepository.findAllByNameContainingIgnoreCase("physics");
@@ -94,8 +94,8 @@ class CourseRepositoryTest extends BaseRepositoryTest {
             .academicTerm(pastTerm)
             .build();
 
-    persistAndFlush(currentCourse);
-    persistAndFlush(pastCourse);
+    courseRepository.save(currentCourse);
+    courseRepository.save(pastCourse);
 
     // When
     List<Course> results = courseRepository.findAllByAcademicTermIsCurrentTrue();
@@ -146,7 +146,7 @@ class CourseRepositoryTest extends BaseRepositoryTest {
             .academicTerm(currentTerm)
             .build();
 
-    Course savedCourse = persistAndFlush(course);
+    Course savedCourse = courseRepository.save(course);
 
     // When
     boolean exists = courseRepository.existsById(savedCourse.getCourseId());
@@ -168,7 +168,7 @@ class CourseRepositoryTest extends BaseRepositoryTest {
             .academicTerm(currentTerm)
             .build();
 
-    Course savedCourse = persistAndFlush(course);
+    Course savedCourse = courseRepository.save(course);
     Long courseId = savedCourse.getCourseId();
 
     // When
@@ -191,7 +191,7 @@ class CourseRepositoryTest extends BaseRepositoryTest {
             .academicTerm(currentTerm)
             .build();
 
-    Course savedCourse = persistAndFlush(course);
+    Course savedCourse = courseRepository.save(course);
 
     // When
     Optional<Course> result = courseRepository.findById(savedCourse.getCourseId());
@@ -221,7 +221,7 @@ class CourseRepositoryTest extends BaseRepositoryTest {
             .academicTerm(currentTerm)
             .build();
 
-    persistAndFlush(course);
+    courseRepository.save(course);
 
     // When
     List<Course> results = courseRepository.findAllByNameContainingIgnoreCase("");

--- a/src/test/java/edu/handong/csee/histudy/repository/StudyApplicantRepositoryTest.java
+++ b/src/test/java/edu/handong/csee/histudy/repository/StudyApplicantRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import edu.handong.csee.histudy.domain.*;
 import edu.handong.csee.histudy.repository.jpa.JpaStudyApplicantRepository;
+import edu.handong.csee.histudy.repository.jpa.JpaStudyGroupRepository;
 import edu.handong.csee.histudy.support.BaseRepositoryTest;
 import edu.handong.csee.histudy.support.TestDataFactory;
 import java.util.List;
@@ -14,13 +15,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 class StudyApplicantRepositoryTest extends BaseRepositoryTest {
 
   @Autowired private JpaStudyApplicantRepository studyApplicantRepository;
+  @Autowired private JpaStudyGroupRepository studyGroupRepository;
 
   @Test
   void 사용자와학기로조회시_해당신청서반환() {
     // Given
     StudyApplicant applicant =
         TestDataFactory.createStudyApplicant(currentTerm, user1, List.of(user2), List.of(course1));
-    persistAndFlush(applicant);
+    studyApplicantRepository.save(applicant);
 
     // When
     Optional<StudyApplicant> result =
@@ -50,13 +52,12 @@ class StudyApplicantRepositoryTest extends BaseRepositoryTest {
     StudyApplicant unassignedApplicant2 =
         TestDataFactory.createStudyApplicant(currentTerm, user2, List.of(user1), List.of(course1));
 
+    studyApplicantRepository.save(unassignedApplicant1);
+    studyApplicantRepository.save(unassignedApplicant2);
+
     // Create a study group and assign one applicant
     StudyGroup studyGroup = StudyGroup.of(1, currentTerm, List.of(unassignedApplicant2));
-    unassignedApplicant2.joinStudyGroup(studyGroup);
-
-    persistAndFlush(unassignedApplicant1);
-    persistAndFlush(unassignedApplicant2);
-    persistAndFlush(studyGroup);
+    studyGroupRepository.save(studyGroup);
 
     // When
     List<StudyApplicant> unassignedApplicants =
@@ -76,13 +77,11 @@ class StudyApplicantRepositoryTest extends BaseRepositoryTest {
     StudyApplicant applicant2 =
         TestDataFactory.createStudyApplicant(currentTerm, user2, List.of(user1), List.of(course1));
 
-    StudyGroup studyGroup = StudyGroup.of(1, currentTerm, List.of(applicant1, applicant2));
-    applicant1.joinStudyGroup(studyGroup);
-    applicant2.joinStudyGroup(studyGroup);
+    studyApplicantRepository.save(applicant1);
+    studyApplicantRepository.save(applicant2);
 
-    persistAndFlush(applicant1);
-    persistAndFlush(applicant2);
-    persistAndFlush(studyGroup);
+    StudyGroup studyGroup = StudyGroup.of(1, currentTerm, List.of(applicant1, applicant2));
+    studyGroupRepository.save(studyGroup);
 
     // When
     List<StudyApplicant> assignedApplicants =
@@ -101,8 +100,8 @@ class StudyApplicantRepositoryTest extends BaseRepositoryTest {
     StudyApplicant pastApplicant =
         TestDataFactory.createStudyApplicant(pastTerm, user2, List.of(user1), List.of(course2));
 
-    persistAndFlush(currentApplicant);
-    persistAndFlush(pastApplicant);
+    studyApplicantRepository.save(currentApplicant);
+    studyApplicantRepository.save(pastApplicant);
 
     // When
     List<StudyApplicant> currentTermApplicants =
@@ -127,18 +126,15 @@ class StudyApplicantRepositoryTest extends BaseRepositoryTest {
     StudyApplicant applicant3 =
         TestDataFactory.createStudyApplicant(currentTerm, user3, List.of(), List.of(course2));
 
+    studyApplicantRepository.save(applicant1);
+    studyApplicantRepository.save(applicant2);
+    studyApplicantRepository.save(applicant3);
+
     StudyGroup studyGroup1 = StudyGroup.of(1, currentTerm, List.of(applicant1, applicant2));
     StudyGroup studyGroup2 = StudyGroup.of(2, currentTerm, List.of(applicant3));
 
-    applicant1.joinStudyGroup(studyGroup1);
-    applicant2.joinStudyGroup(studyGroup1);
-    applicant3.joinStudyGroup(studyGroup2);
-
-    persistAndFlush(applicant1);
-    persistAndFlush(applicant2);
-    persistAndFlush(applicant3);
-    persistAndFlush(studyGroup1);
-    persistAndFlush(studyGroup2);
+    studyGroupRepository.save(studyGroup1);
+    studyGroupRepository.save(studyGroup2);
 
     // When
     List<StudyApplicant> group1Applicants =
@@ -177,7 +173,7 @@ class StudyApplicantRepositoryTest extends BaseRepositoryTest {
     // Given
     StudyApplicant applicant =
         TestDataFactory.createStudyApplicant(currentTerm, user1, List.of(user2), List.of(course1));
-    StudyApplicant savedApplicant = persistAndFlush(applicant);
+    StudyApplicant savedApplicant = studyApplicantRepository.save(applicant);
 
     // When
     studyApplicantRepository.delete(savedApplicant);
@@ -194,7 +190,7 @@ class StudyApplicantRepositoryTest extends BaseRepositoryTest {
     // Given - 다른 학기 신청자만 존재
     StudyApplicant pastApplicant =
         TestDataFactory.createStudyApplicant(pastTerm, user1, List.of(user2), List.of(course1));
-    persistAndFlush(pastApplicant);
+    studyApplicantRepository.save(pastApplicant);
 
     // When
     List<StudyApplicant> currentTermApplicants =

--- a/src/test/java/edu/handong/csee/histudy/repository/StudyGroupRepositoryTest.java
+++ b/src/test/java/edu/handong/csee/histudy/repository/StudyGroupRepositoryTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import edu.handong.csee.histudy.domain.*;
 import edu.handong.csee.histudy.repository.jpa.JpaStudyApplicantRepository;
 import edu.handong.csee.histudy.repository.jpa.JpaStudyGroupRepository;
-import edu.handong.csee.histudy.repository.jpa.JpaStudyReportRepository;
 import edu.handong.csee.histudy.support.BaseRepositoryTest;
 import edu.handong.csee.histudy.support.TestDataFactory;
 import java.util.List;
@@ -17,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 class StudyGroupRepositoryTest extends BaseRepositoryTest {
 
   @Autowired private JpaStudyGroupRepository studyGroupRepository;
-  @Autowired private JpaStudyReportRepository studyReportRepository;
   @Autowired private JpaStudyApplicantRepository studyApplicantRepository;
 
   @Test
@@ -28,10 +26,11 @@ class StudyGroupRepositoryTest extends BaseRepositoryTest {
     StudyApplicant applicant2 =
         TestDataFactory.createStudyApplicant(currentTerm, user2, List.of(user1), List.of(course1));
 
+    studyApplicantRepository.save(applicant1);
+    studyApplicantRepository.save(applicant2);
+
     StudyGroup studyGroup = StudyGroup.of(1, currentTerm, List.of(applicant1, applicant2));
-    persistAndFlush(applicant1);
-    persistAndFlush(applicant2);
-    persistAndFlush(studyGroup);
+    studyGroupRepository.save(studyGroup);
 
     // When
     Optional<StudyGroup> result = studyGroupRepository.findByTagAndAcademicTerm(1, currentTerm);
@@ -57,9 +56,9 @@ class StudyGroupRepositoryTest extends BaseRepositoryTest {
     StudyGroup studyGroup2 = TestDataFactory.createStudyGroup(3, currentTerm);
     StudyGroup studyGroup3 = TestDataFactory.createStudyGroup(2, currentTerm);
 
-    persistAndFlush(studyGroup1);
-    persistAndFlush(studyGroup2);
-    persistAndFlush(studyGroup3);
+    studyGroupRepository.save(studyGroup1);
+    studyGroupRepository.save(studyGroup2);
+    studyGroupRepository.save(studyGroup3);
 
     // When
     Optional<Integer> maxTag = studyGroupRepository.countMaxTag(currentTerm);
@@ -85,9 +84,9 @@ class StudyGroupRepositoryTest extends BaseRepositoryTest {
     StudyGroup studyGroup1 = TestDataFactory.createStudyGroup(1, currentTerm);
     StudyGroup studyGroup2 = TestDataFactory.createStudyGroup(2, currentTerm);
 
-    persistAndFlush(studyGroup3);
-    persistAndFlush(studyGroup1);
-    persistAndFlush(studyGroup2);
+    studyGroupRepository.save(studyGroup3);
+    studyGroupRepository.save(studyGroup1);
+    studyGroupRepository.save(studyGroup2);
 
     // When
     List<StudyGroup> studyGroups = studyGroupRepository.findAllByAcademicTerm(currentTerm);
@@ -102,10 +101,9 @@ class StudyGroupRepositoryTest extends BaseRepositoryTest {
     // Given
     StudyApplicant applicant =
         TestDataFactory.createStudyApplicant(currentTerm, user1, List.of(user2), List.of(course1));
+    studyApplicantRepository.save(applicant);
     StudyGroup studyGroup = StudyGroup.of(1, currentTerm, List.of(applicant));
-
-    persistAndFlush(applicant);
-    persistAndFlush(studyGroup);
+    studyGroupRepository.save(studyGroup);
 
     // When
     Optional<StudyGroup> result = studyGroupRepository.findByUserAndTerm(user1, currentTerm);
@@ -129,14 +127,14 @@ class StudyGroupRepositoryTest extends BaseRepositoryTest {
   void 빈그룹삭제실행시_빈그룹만삭제성공() {
     // Given - 빈 그룹 생성
     StudyGroup emptyGroup = TestDataFactory.createStudyGroup(1, currentTerm);
-    persistAndFlush(emptyGroup);
+    studyGroupRepository.save(emptyGroup);
 
     // 멤버가 있는 그룹 생성
     StudyApplicant applicant =
         TestDataFactory.createStudyApplicant(currentTerm, user1, List.of(user2), List.of(course1));
+    studyApplicantRepository.save(applicant);
     StudyGroup groupWithMembers = StudyGroup.of(2, currentTerm, List.of(applicant));
-    persistAndFlush(applicant);
-    persistAndFlush(groupWithMembers);
+    studyGroupRepository.save(groupWithMembers);
 
     // When
     studyGroupRepository.deleteEmptyGroup(currentTerm);
@@ -180,8 +178,8 @@ class StudyGroupRepositoryTest extends BaseRepositoryTest {
     StudyGroup currentGroup = TestDataFactory.createStudyGroup(1, currentTerm);
     StudyGroup pastGroup = TestDataFactory.createStudyGroup(1, pastTerm);
 
-    persistAndFlush(currentGroup);
-    persistAndFlush(pastGroup);
+    studyGroupRepository.save(currentGroup);
+    studyGroupRepository.save(pastGroup);
 
     // When
     List<StudyGroup> currentGroups = studyGroupRepository.findAllByAcademicTerm(currentTerm);

--- a/src/test/java/edu/handong/csee/histudy/repository/StudyReportRepositoryTest.java
+++ b/src/test/java/edu/handong/csee/histudy/repository/StudyReportRepositoryTest.java
@@ -12,7 +12,6 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.annotation.DirtiesContext;
 
 class StudyReportRepositoryTest extends BaseRepositoryTest {
 
@@ -44,8 +43,7 @@ class StudyReportRepositoryTest extends BaseRepositoryTest {
   }
 
   @Test
-  @DirtiesContext
-  void 스터디그룹별보고서조회시_생성일자내림차순정렬반환() throws InterruptedException {
+  void 스터디그룹별보고서조회시_생성일자내림차순정렬반환() {
     // Given
     StudyReport report1 =
         StudyReport.builder()

--- a/src/test/java/edu/handong/csee/histudy/repository/StudyReportRepositoryTest.java
+++ b/src/test/java/edu/handong/csee/histudy/repository/StudyReportRepositoryTest.java
@@ -3,6 +3,8 @@ package edu.handong.csee.histudy.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import edu.handong.csee.histudy.domain.*;
+import edu.handong.csee.histudy.repository.jpa.JpaStudyApplicantRepository;
+import edu.handong.csee.histudy.repository.jpa.JpaStudyGroupRepository;
 import edu.handong.csee.histudy.repository.jpa.JpaStudyReportRepository;
 import edu.handong.csee.histudy.support.BaseRepositoryTest;
 import edu.handong.csee.histudy.support.TestDataFactory;
@@ -15,25 +17,30 @@ import org.springframework.test.annotation.DirtiesContext;
 class StudyReportRepositoryTest extends BaseRepositoryTest {
 
   @Autowired private JpaStudyReportRepository studyReportRepository;
+  @Autowired private JpaStudyGroupRepository studyGroupRepository;
+  @Autowired private JpaStudyApplicantRepository studyApplicantRepository;
 
   private StudyGroup studyGroup1;
   private StudyGroup studyGroup2;
 
   @BeforeEach
   void setUp() {
-    // Create study groups
     StudyApplicant applicant1 =
         TestDataFactory.createStudyApplicant(currentTerm, user1, List.of(), List.of(course1));
     StudyApplicant applicant2 =
         TestDataFactory.createStudyApplicant(currentTerm, user2, List.of(), List.of(course2));
 
-    studyGroup1 = StudyGroup.of(1, currentTerm, List.of(applicant1));
-    studyGroup2 = StudyGroup.of(2, currentTerm, List.of(applicant2));
+    studyApplicantRepository.save(applicant1);
+    studyApplicantRepository.save(applicant2);
 
-    persistAndFlush(applicant1);
-    persistAndFlush(applicant2);
-    persistAndFlush(studyGroup1);
-    persistAndFlush(studyGroup2);
+    studyGroup1 = TestDataFactory.createStudyGroup(1, currentTerm);
+    studyGroup2 = TestDataFactory.createStudyGroup(2, currentTerm);
+
+    studyGroupRepository.save(studyGroup1);
+    studyGroupRepository.save(studyGroup2);
+
+    applicant1.joinStudyGroup(studyGroup1);
+    applicant2.joinStudyGroup(studyGroup2);
   }
 
   @Test
@@ -74,9 +81,9 @@ class StudyReportRepositoryTest extends BaseRepositoryTest {
             .build();
 
     // Save reports with order: report1 first, then report2, then report3
-    persistAndFlush(report1);
-    persistAndFlush(report2);
-    persistAndFlush(report3);
+    studyReportRepository.save(report1);
+    studyReportRepository.save(report2);
+    studyReportRepository.save(report3);
 
     // When
     List<StudyReport> group1Reports =
@@ -124,7 +131,7 @@ class StudyReportRepositoryTest extends BaseRepositoryTest {
   void 스터디보고서삭제시_삭제성공() {
     // Given
     StudyReport report = TestDataFactory.createStudyReport(studyGroup1, "Test Report");
-    StudyReport savedReport = persistAndFlush(report);
+    StudyReport savedReport = studyReportRepository.save(report);
 
     // When
     studyReportRepository.delete(savedReport);
@@ -158,8 +165,8 @@ class StudyReportRepositoryTest extends BaseRepositoryTest {
     StudyReport group1Report = TestDataFactory.createStudyReport(studyGroup1, "Group 1 Report");
     StudyReport group2Report = TestDataFactory.createStudyReport(studyGroup2, "Group 2 Report");
 
-    persistAndFlush(group1Report);
-    persistAndFlush(group2Report);
+    studyReportRepository.save(group1Report);
+    studyReportRepository.save(group2Report);
 
     // When
     List<StudyReport> group1Reports =

--- a/src/test/java/edu/handong/csee/histudy/repository/StudyReportRepositoryTest.java
+++ b/src/test/java/edu/handong/csee/histudy/repository/StudyReportRepositoryTest.java
@@ -45,7 +45,7 @@ class StudyReportRepositoryTest extends BaseRepositoryTest {
 
   @Test
   @DirtiesContext
-  void 스터디그룹별보고서조회시_생성일자내림차순정렬반환() {
+  void 스터디그룹별보고서조회시_생성일자내림차순정렬반환() throws InterruptedException {
     // Given
     StudyReport report1 =
         StudyReport.builder()
@@ -94,9 +94,7 @@ class StudyReportRepositoryTest extends BaseRepositoryTest {
     // Then
     assertThat(group1Reports).hasSize(2);
     // Since we can't guarantee order with identical timestamps, just verify group membership
-    assertThat(group1Reports)
-        .extracting("title")
-        .containsExactlyInAnyOrder("First Report", "Second Report");
+    assertThat(group1Reports).extracting("title").containsExactly("Second Report", "First Report");
     assertThat(group1Reports).allMatch(report -> report.getStudyGroup().equals(studyGroup1));
 
     assertThat(group2Reports).hasSize(1);

--- a/src/test/java/edu/handong/csee/histudy/repository/UserRepositoryTest.java
+++ b/src/test/java/edu/handong/csee/histudy/repository/UserRepositoryTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import jakarta.persistence.PersistenceException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Sort;
 
 class UserRepositoryTest extends BaseRepositoryTest {
@@ -25,7 +25,7 @@ class UserRepositoryTest extends BaseRepositoryTest {
     User user =
         TestDataFactory.createUser(
             "google-sub-901", "22500901", "test901@example.com", "Test User", Role.USER);
-    persistAndFlush(user);
+    userRepository.save(user);
 
     // When
     Optional<User> result = userRepository.findUserBySid("22500901");
@@ -50,7 +50,7 @@ class UserRepositoryTest extends BaseRepositoryTest {
     User user =
         TestDataFactory.createUser(
             "google-sub-902", "22500902", "test902@example.com", "Test User", Role.USER);
-    persistAndFlush(user);
+    userRepository.save(user);
 
     // When
     Optional<User> result = userRepository.findUserByEmail("test902@example.com");
@@ -75,7 +75,7 @@ class UserRepositoryTest extends BaseRepositoryTest {
     User user =
         TestDataFactory.createUser(
             "google-sub-903", "22500903", "test903@example.com", "Test User", Role.USER);
-    persistAndFlush(user);
+    userRepository.save(user);
 
     // When
     Optional<User> result = userRepository.findUserBySub("google-sub-903");
@@ -96,9 +96,9 @@ class UserRepositoryTest extends BaseRepositoryTest {
     User bobUser =
         TestDataFactory.createUser("sub-bob", "22500906", "bob@test.com", "Bob Johnson", Role.USER);
 
-    persistAndFlush(johnUser);
-    persistAndFlush(janeUser);
-    persistAndFlush(bobUser);
+    userRepository.save(johnUser);
+    userRepository.save(janeUser);
+    userRepository.save(bobUser);
 
     // When - 이름으로 검색 (부분 매칭으로 "Doe"만 검색)
     List<User> nameResults = userRepository.findUserByNameOrSidOrEmail("Doe");
@@ -123,7 +123,7 @@ class UserRepositoryTest extends BaseRepositoryTest {
     // Given
     User user =
         TestDataFactory.createUser("sub-test", "22500907", "test907@example.com", "Test User", Role.USER);
-    persistAndFlush(user);
+    userRepository.save(user);
 
     // When
     List<User> results = userRepository.findUserByNameOrSidOrEmail("nonexistent");
@@ -137,7 +137,7 @@ class UserRepositoryTest extends BaseRepositoryTest {
     // Given
     User user =
         TestDataFactory.createUser("sub-id", "22500908", "test908@example.com", "Test User", Role.USER);
-    User savedUser = persistAndFlush(user);
+    User savedUser = userRepository.save(user);
 
     // When
     Optional<User> result = userRepository.findById(savedUser.getUserId());
@@ -158,9 +158,9 @@ class UserRepositoryTest extends BaseRepositoryTest {
     User bobUser =
         TestDataFactory.createUser("sub-bobby", "22500911", "bobby@example.com", "Bobby", Role.USER);
 
-    persistAndFlush(charlieUser);
-    persistAndFlush(aliceUser);
-    persistAndFlush(bobUser);
+    userRepository.save(charlieUser);
+    userRepository.save(aliceUser);
+    userRepository.save(bobUser);
 
     // When - 이름으로 오름차순 정렬
     List<User> results = userRepository.findAll(Sort.by("name"));
@@ -206,11 +206,16 @@ class UserRepositoryTest extends BaseRepositoryTest {
     User user2 =
         TestDataFactory.createUser("sub-dup2", "22500982", "same@example.com", "User 2", Role.USER);
 
-    persistAndFlush(user1);
+    userRepository.save(user1);
+    flushAndClear();
 
     // When & Then
-    assertThatThrownBy(() -> persistAndFlush(user2))
-        .isInstanceOf(PersistenceException.class);
+    assertThatThrownBy(
+            () -> {
+              userRepository.save(user2);
+              flushAndClear();
+            })
+        .isInstanceOf(DataIntegrityViolationException.class);
   }
 
   @Test
@@ -221,11 +226,16 @@ class UserRepositoryTest extends BaseRepositoryTest {
     User user2 =
         TestDataFactory.createUser("sub-dup4", "22500983", "user2@example.com", "User 2", Role.USER);
 
-    persistAndFlush(user1);
+    userRepository.save(user1);
+    flushAndClear();
 
     // When & Then
-    assertThatThrownBy(() -> persistAndFlush(user2))
-        .isInstanceOf(PersistenceException.class);
+    assertThatThrownBy(
+            () -> {
+              userRepository.save(user2);
+              flushAndClear();
+            })
+        .isInstanceOf(DataIntegrityViolationException.class);
   }
 
   @Test
@@ -238,11 +248,16 @@ class UserRepositoryTest extends BaseRepositoryTest {
         TestDataFactory.createUser(
             "same-sub", "22500985", "user4@example.com", "User 2", Role.USER);
 
-    persistAndFlush(user1);
+    userRepository.save(user1);
+    flushAndClear();
 
     // When & Then
-    assertThatThrownBy(() -> persistAndFlush(user2))
-        .isInstanceOf(PersistenceException.class);
+    assertThatThrownBy(
+            () -> {
+              userRepository.save(user2);
+              flushAndClear();
+            })
+        .isInstanceOf(DataIntegrityViolationException.class);
   }
 
   @Test

--- a/src/test/java/edu/handong/csee/histudy/service/TeamServiceTest.java
+++ b/src/test/java/edu/handong/csee/histudy/service/TeamServiceTest.java
@@ -68,8 +68,10 @@ public class TeamServiceTest {
     Course course = TestDataFactory.createCourse("Introduction to Test", "ECE00103", "John", term);
     courseRepository.saveAll(List.of(course));
 
-    StudyApplicant studyApplicant1 = TestDataFactory.createStudyApplicant(term, student1, List.of(student2), List.of(course));
-    StudyApplicant studyApplicant2 = TestDataFactory.createStudyApplicant(term, student2, List.of(student1), List.of(course));
+    StudyApplicant studyApplicant1 =
+        TestDataFactory.createStudyApplicant(term, student1, List.of(student2), List.of(course));
+    StudyApplicant studyApplicant2 =
+        TestDataFactory.createStudyApplicant(term, student2, List.of(student1), List.of(course));
 
     studyApplicantRepository.save(studyApplicant1);
     studyApplicantRepository.save(studyApplicant2);
@@ -243,50 +245,6 @@ public class TeamServiceTest {
     assertThat(teams).hasSize(1);
     assertThat(teams.get(0).getGroup()).isEqualTo(studyGroup.getStudyGroupId());
     assertThat(teams.get(0).getTag()).isEqualTo(1);
-  }
-
-  @Test
-  void 유효한팀ID시_삭제성공() {
-    // Given
-    AcademicTerm term =
-        AcademicTerm.builder().academicYear(2025).semester(TermType.SPRING).isCurrent(true).build();
-    academicTermRepository.save(term);
-
-    User student1 =
-        User.builder().sub("1").sid("22500101").email("user1@test.com").name("Foo").build();
-    userRepository.save(student1);
-
-    Course course = new Course("Introduction to Test", "ECE00103", "John", term);
-    courseRepository.saveAll(List.of(course));
-
-    StudyApplicant studyApplicant1 = StudyApplicant.of(term, student1, List.of(), List.of(course));
-    studyApplicantRepository.save(studyApplicant1);
-
-    StudyGroup studyGroup = StudyGroup.of(1, term, List.of(studyApplicant1));
-    studyGroupRepository.save(studyGroup);
-
-    TeamIdDto dto = new TeamIdDto();
-    dto.setGroupId(studyGroup.getStudyGroupId());
-
-    // When
-    int result = teamService.deleteTeam(dto, "admin@test.com");
-
-    // Then
-    assertThat(result).isEqualTo(1);
-    assertThat(studyGroupRepository.existsById(studyGroup.getStudyGroupId())).isFalse();
-  }
-
-  @Test
-  void 존재하지않는팀ID시_0반환() {
-    // Given
-    TeamIdDto dto = new TeamIdDto();
-    dto.setGroupId(999L);
-
-    // When
-    int result = teamService.deleteTeam(dto, "admin@test.com");
-
-    // Then
-    assertThat(result).isEqualTo(0);
   }
 
   @Test

--- a/src/test/java/edu/handong/csee/histudy/service/TeamServiceTest.java
+++ b/src/test/java/edu/handong/csee/histudy/service/TeamServiceTest.java
@@ -400,4 +400,122 @@ public class TeamServiceTest {
       assertThat(allGroupsHaveMinMembers).isTrue();
     }
   }
+
+  @Test
+  void 다양한선호과목과친구요청으로복합매칭() {
+    // Given
+    AcademicTerm term =
+        AcademicTerm.builder().academicYear(2025).semester(TermType.SPRING).isCurrent(true).build();
+    academicTermRepository.save(term);
+
+    // Create various courses
+    Course mathCourse = new Course("Calculus I", "MAT101", "Prof. Smith", term);
+    Course physicsCourse = new Course("Physics I", "PHY101", "Prof. Johnson", term);
+    Course chemCourse = new Course("Chemistry I", "CHE101", "Prof. Brown", term);
+    Course csCourse = new Course("Programming I", "CS101", "Prof. Davis", term);
+    Course engCourse = new Course("English I", "ENG101", "Prof. Wilson", term);
+    courseRepository.saveAll(List.of(mathCourse, physicsCourse, chemCourse, csCourse, engCourse));
+
+    // Create 12 users with different preferences
+    User[] users = new User[12];
+    StudyApplicant[] applicants = new StudyApplicant[12];
+
+    for (int i = 0; i < 12; i++) {
+      users[i] =
+          User.builder()
+              .sub("user" + (i + 1))
+              .sid("22500" + String.format("%03d", i + 101))
+              .email("user" + (i + 1) + "@test.com")
+              .name("Student" + (i + 1))
+              .build();
+      userRepository.save(users[i]);
+    }
+
+    // Create applicants with diverse course preferences and friend requests
+
+    // Group 1: Math lovers (users 0, 1, 2) with friend requests
+    applicants[0] =
+        StudyApplicant.of(
+            term, users[0], List.of(users[1], users[2]), List.of(mathCourse, physicsCourse));
+    applicants[1] =
+        StudyApplicant.of(term, users[1], List.of(users[0]), List.of(mathCourse, chemCourse));
+    applicants[2] =
+        StudyApplicant.of(term, users[2], List.of(users[0]), List.of(mathCourse, engCourse));
+
+    // Group 2: Physics enthusiasts (users 3, 4, 5, 6)
+    applicants[3] =
+        StudyApplicant.of(term, users[3], List.of(), List.of(physicsCourse, mathCourse));
+    applicants[4] =
+        StudyApplicant.of(term, users[4], List.of(), List.of(physicsCourse, chemCourse));
+    applicants[5] =
+        StudyApplicant.of(term, users[5], List.of(users[4]), List.of(physicsCourse, csCourse));
+    applicants[6] = StudyApplicant.of(term, users[6], List.of(), List.of(physicsCourse, engCourse));
+
+    // Group 3: CS focused (users 7, 8, 9)
+    applicants[7] =
+        StudyApplicant.of(term, users[7], List.of(users[8]), List.of(csCourse, mathCourse));
+    applicants[8] =
+        StudyApplicant.of(term, users[8], List.of(users[7]), List.of(csCourse, physicsCourse));
+    applicants[9] = StudyApplicant.of(term, users[9], List.of(), List.of(csCourse, chemCourse));
+
+    // Individual preferences (users 10, 11)
+    applicants[10] = StudyApplicant.of(term, users[10], List.of(), List.of(chemCourse, engCourse));
+    applicants[11] = StudyApplicant.of(term, users[11], List.of(), List.of(engCourse, mathCourse));
+
+    for (StudyApplicant applicant : applicants) {
+      studyApplicantRepository.save(applicant);
+    }
+
+    // When
+    teamService.matchTeam();
+
+    // Then
+    List<StudyGroup> groups = studyGroupRepository.findAllByAcademicTerm(term);
+
+    assertThat(groups).isNotEmpty();
+
+    // Verify all applicants are assigned to groups
+    int totalAssignedMembers = groups.stream().mapToInt(g -> g.getMembers().size()).sum();
+
+    // Should have most applicants assigned (some might be unassigned due to group size constraints)
+    assertThat(totalAssignedMembers).isGreaterThan(0);
+
+    // Verify group size constraints (3-5 members per group)
+    boolean allGroupsHaveValidSize =
+        groups.stream().allMatch(g -> g.getMembers().size() >= 3 && g.getMembers().size() <= 5);
+    assertThat(allGroupsHaveValidSize).isTrue();
+
+    // Verify unique tags
+    List<Integer> tags = groups.stream().map(StudyGroup::getTag).toList();
+    assertThat(tags).doesNotHaveDuplicates();
+
+    // Verify friend requests were prioritized (users 0, 1, 2 should be together if possible)
+    boolean foundFriendGroup =
+        groups.stream()
+            .anyMatch(
+                group -> {
+                  List<User> groupUsers =
+                      group.getMembers().stream().map(StudyApplicant::getUser).toList();
+                  return groupUsers.contains(users[0])
+                      && (groupUsers.contains(users[1]) || groupUsers.contains(users[2]));
+                });
+
+    // Friend matching should be attempted but not guaranteed due to other constraints
+    // This test verifies the algorithm runs without errors and produces valid groups
+
+    // Log for debugging
+    System.out.println(
+        "Created " + groups.size() + " groups with " + totalAssignedMembers + " total members");
+    for (int i = 0; i < groups.size(); i++) {
+      StudyGroup group = groups.get(i);
+      System.out.println(
+          "Group "
+              + (i + 1)
+              + " (Tag: "
+              + group.getTag()
+              + "): "
+              + group.getMembers().size()
+              + " members");
+    }
+  }
 }

--- a/src/test/java/edu/handong/csee/histudy/service/repository/fake/FakeStudyGroupRepository.java
+++ b/src/test/java/edu/handong/csee/histudy/service/repository/fake/FakeStudyGroupRepository.java
@@ -41,11 +41,6 @@ public class FakeStudyGroupRepository implements StudyGroupRepository {
   }
 
   @Override
-  public boolean existsById(Long id) {
-    return store.stream().anyMatch(e -> e.getStudyGroupId().equals(id));
-  }
-
-  @Override
   public void deleteById(Long id) {
     store.removeIf(e -> e.getStudyGroupId().equals(id));
   }
@@ -60,6 +55,13 @@ public class FakeStudyGroupRepository implements StudyGroupRepository {
     ReflectionTestUtils.setField(entity, "studyGroupId", sequence++);
     store.add(entity);
     return entity;
+  }
+
+  @Override
+  public List<StudyGroup> saveAll(Iterable<StudyGroup> entities) {
+    List<StudyGroup> saved = new ArrayList<>();
+    entities.forEach(entity -> saved.add(save(entity)));
+    return saved;
   }
 
   @Override

--- a/src/test/java/edu/handong/csee/histudy/support/BaseRepositoryTest.java
+++ b/src/test/java/edu/handong/csee/histudy/support/BaseRepositoryTest.java
@@ -2,15 +2,18 @@ package edu.handong.csee.histudy.support;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import edu.handong.csee.histudy.config.JpaConfig;
 import edu.handong.csee.histudy.domain.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(JpaConfig.class)
 public abstract class BaseRepositoryTest {
 
     @Autowired


### PR DESCRIPTION
- 그룹 삭제 API 제거

  > 사용하지 않는 API를 제거했습니다. 

- 그룹 멤버 변경시 공통 과목이 올바르게 갱신되지 않는 버그 수정

  > 자동 매칭이 아닌 수동으로 멤버를 그룹에 배정할 때 공통 과목이 올바르게 갱신되지 않는 버그가 있었습니다. 이제는 그룹 인원에 변동이 생기면 모든 멤버를 대상으로 공통 과목을 항상 다시 계산하도록 수정했습니다.

- 그룹을 명시적으로 저장하도록 리팩토링

  > 기존에는 StudyGroup 엔티티가 CascadeType.PERSIST를 통해 별도의 save() 호출 없이 자동으로 추가되었습니다. 기능상 문제는 없었으나, 엔티티 경계가 StudyApplicant에 과도하게 종속된 것처럼 보일 수 있어 명시적으로 저장하도록 변경했습니다.

---

Closes #186 